### PR TITLE
Fix main loop stability and add game-start detection

### DIFF
--- a/diagnose.py
+++ b/diagnose.py
@@ -1,0 +1,85 @@
+"""
+Quick diagnostic — run this before enhanced_bot.py to find out
+what's missing or broken on your system.
+
+Usage:
+    python diagnose.py
+"""
+
+import sys
+
+print("=" * 50)
+print("Among Us Bot — Diagnostics")
+print("=" * 50)
+print(f"Python: {sys.version}\n")
+
+all_ok = True
+
+def check(label, fn):
+    global all_ok
+    try:
+        result = fn()
+        print(f"  [OK]  {label}" + (f"  →  {result}" if result else ""))
+    except Exception as e:
+        print(f"  [FAIL] {label}")
+        print(f"         {e}")
+        all_ok = False
+
+# ── Core imports ────────────────────────────────────────────────
+print("[ Imports ]")
+check("numpy",     lambda: __import__("numpy").__version__)
+check("cv2",       lambda: __import__("cv2").__version__)
+check("pyautogui", lambda: __import__("pyautogui").__version__)
+check("dxcam",     lambda: __import__("dxcam").__version__)
+
+# ── Optional OCR ────────────────────────────────────────────────
+print()
+print("[ OCR (optional) ]")
+try:
+    import pytesseract
+    print(f"  [OK]  pytesseract  →  {pytesseract.__version__}")
+    try:
+        ver = pytesseract.get_tesseract_version()
+        print(f"  [OK]  Tesseract binary  →  {ver}")
+    except Exception as e:
+        print(f"  [WARN] Tesseract binary not found — OCR will be disabled")
+        print(f"         Download from: https://github.com/UB-Mannheim/tesseract/wiki")
+        print(f"         Error: {e}")
+except ImportError:
+    print("  [WARN] pytesseract not installed — run: pip install pytesseract")
+
+# ── Screen capture ───────────────────────────────────────────────
+print()
+print("[ Screen capture ]")
+def test_dxcam():
+    import dxcam
+    cam = dxcam.create()
+    frame = cam.grab()
+    if frame is None:
+        raise RuntimeError("grab() returned None — is your display active?")
+    return f"frame shape: {frame.shape}"
+
+check("dxcam grab()", test_dxcam)
+
+# ── Game window ──────────────────────────────────────────────────
+print()
+print("[ Among Us window ]")
+def test_window():
+    import pyautogui
+    wins = pyautogui.getWindowsWithTitle("Among Us")
+    if not wins:
+        raise RuntimeError("Among Us window not found — is the game running?")
+    w = wins[0]
+    return f"'{w.title}'  at ({w.left},{w.top})  size {w.width}x{w.height}"
+
+check("Among Us window", test_window)
+
+# ── Summary ──────────────────────────────────────────────────────
+print()
+print("=" * 50)
+if all_ok:
+    print("All checks passed — you can run: python enhanced_bot.py")
+else:
+    print("Some checks FAILED — fix the issues above, then re-run this script.")
+print("=" * 50)
+input("\nPress Enter to exit...")   # keeps the window open if double-clicked

--- a/enhanced_bot.py
+++ b/enhanced_bot.py
@@ -31,21 +31,24 @@ class EnhancedAmongUsBot:
 
         # Game state
         self.state = None
+        self._prev_state = None   # used to detect state transitions
         self.is_impostor = False
         self.is_dead = False
         self.in_voting = False
+        self._role_locked = False  # True once role has been read this round
         self._last_role_result: RoleDetectionResult = RoleDetectionResult(
             Role.UNKNOWN, 0.0, "unknown"
         )
-        
+
         # Player tracking
         self.my_position = None
         self.all_players = []
         self.tasks = []
-        
+
         # Statistics
         self.tasks_completed = 0
         self.frame_count = 0
+        self._null_frame_streak = 0  # consecutive None grabs
     
     def _get_window_region(self):
         """Return (left, top, right, bottom) for the Among Us window, or None."""
@@ -59,48 +62,65 @@ class EnhancedAmongUsBot:
         return None
 
     def _grab_frame(self):
-        """Capture only the Among Us window region."""
-        if self.window_region is None:
-            self.window_region = self._get_window_region()
-        if self.window_region is not None:
-            return self.camera.grab(region=self.window_region)
-        return self.camera.grab()  # fallback: full screen
+        """Capture only the Among Us window region. Returns None on failure."""
+        try:
+            if self.window_region is None:
+                self.window_region = self._get_window_region()
+            if self.window_region is not None:
+                return self.camera.grab(region=self.window_region)
+            return self.camera.grab()  # fallback: full screen
+        except Exception as e:
+            logger.debug(f"Frame grab error: {e}")
+            return None
 
     def update_game_state(self, frame):
         """Update all game state information from current frame"""
         if frame is None:
             return
 
-        prev_state = self.state
+        self._prev_state = self.state
 
         # Detect basic state
         self.state = self.detector.detect_menu_state(frame)
 
+        # ── State transition hooks ────────────────────────────────────────
+        if self.state != self._prev_state:
+            logger.info(f"Game state: {self._prev_state} → {self.state}")
+
+            # Returning to menu/lobby means a new round will start — reset role
+            if self.state in ('menu', 'lobby', 'unknown') and self._prev_state == 'in_game':
+                logger.info("Round ended — resetting role for next round")
+                self._role_locked = False
+                self.is_impostor = False
+                self._last_role_result = RoleDetectionResult(Role.UNKNOWN, 0.0, "unknown")
+
         # Detect voting FIRST — other detections depend on this
         self.in_voting = self.detector.detect_voting_screen(frame)
 
-        # Dead detection: voting screen has a dark overlay so skip it
-        # while voting to avoid false positives
+        # Dead detection: skip during voting to avoid false positives
         if self.in_voting:
             self.is_dead = False
         else:
             self.is_dead = self.detector.detect_dead_players(frame)
 
-        # Role detection: run on every frame that looks like a reveal screen,
-        # but only accept a result once per round (cache until next round).
-        # Skip during voting/dead to avoid false positives from UI overlays.
-        if not self.in_voting and not self.is_dead:
+        # ── Role detection ────────────────────────────────────────────────
+        # Only runs when:
+        #   • We haven't locked a role yet this round
+        #   • Not in voting / dead screen (avoids UI false positives)
+        #   • The screen looks like the role-reveal screen (mostly dark)
+        if not self._role_locked and not self.in_voting and not self.is_dead:
             if self.role_detector.is_reveal_screen(frame):
                 result = self.role_detector.detect(frame)
                 if result.role != Role.UNKNOWN:
                     self._last_role_result = result
                     self.is_impostor = (result.role == Role.IMPOSTOR)
-                    logger.info(f"Role locked: {result}")
+                    self._role_locked = True
+                    logger.info(f"Role locked in: {result}")
 
-        # Detect all players (capped to 1 per color so max ~8)
+        # Detect all players (capped to 1 per color)
         self.all_players = self.detector.detect_player_positions(frame)
 
-        # Only detect tasks when actually in game and not voting/dead
+        # Only detect tasks when in game and not voting/dead
         if self.state == 'in_game' and not self.in_voting and not self.is_dead:
             self.tasks = self.detector.detect_task_prompts(frame)
         else:
@@ -157,31 +177,43 @@ class EnhancedAmongUsBot:
             self.tasks_completed += 1
     
     def print_stats(self):
-        """Print current bot statistics to the console, overwriting the previous stats block."""
+        """Print current bot statistics, overwriting the previous stats block."""
         r = self._last_role_result
-        role_text = (
-            f"{r.role.value.upper()}  "
-            f"(conf={r.confidence:.2f} via={r.method})"
-            if r.role.value != "unknown"
-            else "UNKNOWN"
-        )
-        state_text = self.state or "unknown"
-        status     = "ACTIVE"   if self.bot_active  else "PAUSED"
-        flags = []
-        if self.is_dead:    flags.append("DEAD")
-        if self.in_voting:  flags.append("VOTING")
-        flag_str = "  " + " | ".join(flags) if flags else ""
+
+        # Role display
+        if r.role == Role.UNKNOWN:
+            role_text = "--- (waiting for round to start)"
+        else:
+            role_text = (
+                f"{r.role.value.upper()}  "
+                f"(conf={r.confidence:.2f}  via={r.method})"
+            )
+
+        # State display with human-friendly label
+        state_labels = {
+            'menu':    'MENU',
+            'lobby':   'LOBBY — waiting for host to start',
+            'in_game': 'IN GAME',
+            'unknown': 'SCANNING...',
+            None:      'SCANNING...',
+        }
+        state_text = state_labels.get(self.state, self.state or 'SCANNING...')
+
+        status = "ACTIVE" if self.bot_active else "PAUSED"
+        flags  = []
+        if self.is_dead:   flags.append("DEAD")
+        if self.in_voting: flags.append("VOTING")
+        flag_str = "  [" + " | ".join(flags) + "]" if flags else ""
 
         lines = [
             f"  State   : {state_text}",
             f"  Role    : {role_text}",
             f"  Bot     : {status}{flag_str}",
-            f"  Players : {len(self.all_players)}",
-            f"  Tasks   : detected={len(self.tasks)}  completed={self.tasks_completed}",
+            f"  Players : {len(self.all_players)} detected",
+            f"  Tasks   : {len(self.tasks)} visible   {self.tasks_completed} completed",
             f"  Frames  : {self.frame_count}",
         ]
 
-        # Move cursor up to overwrite the previous stats block
         print(f"\033[{len(lines)}A", end="")
         for line in lines:
             print(f"\033[2K{line}")
@@ -218,33 +250,9 @@ class EnhancedAmongUsBot:
 
         try:
             while self.running:
-                # Refresh window region every ~300 frames in case window moved
-                if self.frame_count % 300 == 0:
-                    self.window_region = self._get_window_region()
-                    if self.window_region:
-                        l, t, r, b = self.window_region
-                        logger.info(f"Game window: ({l},{t}) {r-l}x{b-t}")
-                    else:
-                        logger.warning("Among Us window not found - capturing full screen")
+                loop_start = time.perf_counter()
 
-                frame = self._grab_frame()
-
-                if frame is not None:
-                    self.frame_count += 1
-
-                    # Update game state every 3 frames
-                    if self.frame_count % 3 == 0:
-                        self.update_game_state(frame)
-
-                    # Execute bot logic every 30 frames
-                    if self.frame_count % 30 == 0:
-                        self.execute_bot_logic(frame)
-
-                    # Refresh console stats every 15 frames
-                    if self.frame_count % 15 == 0:
-                        self.print_stats()
-
-                # Non-blocking keyboard input (Windows)
+                # ── Keyboard input (non-blocking) ─────────────────────────
                 if msvcrt.kbhit():
                     key = msvcrt.getch()
                     if key == b'q':
@@ -252,16 +260,58 @@ class EnhancedAmongUsBot:
                         break
                     elif key == b' ':
                         self.bot_active = not self.bot_active
-                        status = "ACTIVATED" if self.bot_active else "PAUSED"
-                        logger.info(f"Bot {status}")
+                        logger.info(f"Bot {'ACTIVATED' if self.bot_active else 'PAUSED'}")
                     elif key == b'r':
                         self.tasks_completed = 0
                         logger.info("Statistics reset")
 
+                # ── Window refresh every 5 seconds (~150 frames at 30fps) ─
+                if self.frame_count % 150 == 0:
+                    self.window_region = self._get_window_region()
+                    if self.window_region:
+                        l, t, r, b = self.window_region
+                        logger.debug(f"Game window: ({l},{t}) {r-l}x{b-t}")
+                    else:
+                        logger.warning("Among Us window not found — waiting...")
+
+                # ── Grab frame ────────────────────────────────────────────
+                frame = self._grab_frame()
+
+                if frame is None:
+                    # dxcam returns None when the screen hasn't refreshed yet;
+                    # just wait a tick and try again — don't crash
+                    self._null_frame_streak += 1
+                    if self._null_frame_streak % 60 == 0:
+                        logger.debug(f"No frame for {self._null_frame_streak} ticks — still waiting")
+                    time.sleep(0.05)
+                    continue
+
+                self._null_frame_streak = 0
+                self.frame_count += 1
+
+                # ── Game state detection (every 3 frames) ─────────────────
+                if self.frame_count % 3 == 0:
+                    self.update_game_state(frame)
+
+                # ── Bot actions (every 30 frames ≈ 1 s) ───────────────────
+                if self.frame_count % 30 == 0:
+                    self.execute_bot_logic(frame)
+
+                # ── Stats display (every 15 frames ≈ 0.5 s) ──────────────
+                if self.frame_count % 15 == 0:
+                    self.print_stats()
+
+                # ── Cap to ~30 fps ────────────────────────────────────────
+                elapsed = time.perf_counter() - loop_start
+                sleep_time = max(0.0, (1 / 30) - elapsed)
+                if sleep_time:
+                    time.sleep(sleep_time)
+
         except KeyboardInterrupt:
-            logger.info("Interrupted by user")
+            logger.info("Interrupted by user (Ctrl+C)")
         except Exception as e:
-            logger.error(f"Error in bot loop: {e}", exc_info=True)
+            logger.error(f"Unexpected error in main loop: {e}", exc_info=True)
+            input("Press Enter to exit...")  # keep window open so error is visible
         finally:
             logger.info(f"Bot shutdown. Tasks completed: {self.tasks_completed}")
 


### PR DESCRIPTION
- Add 30fps cap (time.sleep) so dxcam isn't overwhelmed
- Wrap _grab_frame in try/except — null frames now wait and retry instead of crashing
- Track state transitions to detect when a game starts/ends
- Reset cached role when returning to lobby/menu (ready for next round)
- _role_locked flag prevents re-reading role mid-game
- Improve print_stats with human-friendly state labels and waiting messages
- Add input() pause on unexpected crash so error stays visible
- Add diagnose.py for pre-flight dependency checking