### PR TITLE
feat: panel-grade server management features

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +583,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +709,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -846,6 +885,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embed-resource"
@@ -1957,16 +2002,19 @@ name = "launchstone"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chrono",
  "futures-util",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
  "tokio",
  "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -2180,6 +2228,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num-conv"
@@ -2813,6 +2870,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3548,6 +3625,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3615,7 +3706,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3686,7 +3777,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3785,7 +3876,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -3811,7 +3902,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3836,7 +3927,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4700,10 +4791,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -4724,7 +4815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4776,6 +4867,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -4798,12 +4899,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -4815,8 +4928,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -4835,9 +4948,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4886,6 +5021,15 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5271,7 +5415,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5443,10 +5587,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "time",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,3 +23,6 @@ uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3"
 anyhow = "1"
+sysinfo = "0.33"
+zip = { version = "2", default-features = false, features = ["deflate", "time"] }
+base64 = "0.22"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1693,12 +1693,17 @@ pub async fn get_player_list(
 }
 
 #[tauri::command]
+#[tauri::command]
 pub async fn add_to_player_list(
     id: String,
     list_type: String,
     username: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
+    if username.is_empty() || username.len() > 16 || !username.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err("invalid username".to_string());
+    }
+    let filename = player_list_filename(&list_type)?;
     let filename = player_list_filename(&list_type)?;
     let path = state.server_dir(&id).join(filename);
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -64,6 +64,7 @@ fn build_server_command(
 ) -> Result<tokio::process::Command, String> {
     let max_ram = format!("-Xmx{}M", config.max_ram_mb);
     let min_ram = format!("-Xms{}M", std::cmp::min(config.max_ram_mb, 512));
+    let extra: Vec<String> = config.jvm_flags.split_whitespace().map(String::from).collect();
 
     let cmd = match &config.server_type {
         ServerType::Forge | ServerType::Neoforge => {
@@ -87,22 +88,34 @@ fn build_server_command(
                 .find(|n| n.starts_with(prefix) && n.ends_with(".jar") && !n.contains("installer"))
                 .ok_or_else(|| format!("{} server files not found. Installation may have failed.", prefix))?;
             let mut c = tokio::process::Command::new(java);
-            c.args([&max_ram, &min_ram, "-jar", &jar, "nogui"]);
+            let mut args = vec![max_ram.clone(), min_ram.clone()];
+            args.extend(extra.iter().cloned());
+            args.extend(["-jar".to_string(), jar, "nogui".to_string()]);
+            c.args(args);
             c
         }
         ServerType::Fabric => {
             let mut c = tokio::process::Command::new(java);
-            c.args([&max_ram, &min_ram, "-jar", "fabric-server-launch.jar", "nogui"]);
+            let mut args = vec![max_ram.clone(), min_ram.clone()];
+            args.extend(extra.iter().cloned());
+            args.extend(["-jar".to_string(), "fabric-server-launch.jar".to_string(), "nogui".to_string()]);
+            c.args(args);
             c
         }
         ServerType::Quilt => {
             let mut c = tokio::process::Command::new(java);
-            c.args([&max_ram, &min_ram, "-jar", "quilt-server-launch.jar", "nogui"]);
+            let mut args = vec![max_ram.clone(), min_ram.clone()];
+            args.extend(extra.iter().cloned());
+            args.extend(["-jar".to_string(), "quilt-server-launch.jar".to_string(), "nogui".to_string()]);
+            c.args(args);
             c
         }
         _ => {
             let mut c = tokio::process::Command::new(java);
-            c.args([&max_ram, &min_ram, "-jar", &config.jar_name, "nogui"]);
+            let mut args = vec![max_ram.clone(), min_ram.clone()];
+            args.extend(extra.iter().cloned());
+            args.extend(["-jar".to_string(), config.jar_name.clone(), "nogui".to_string()]);
+            c.args(args);
             c
         }
     };
@@ -416,6 +429,8 @@ pub async fn create_server(
         max_ram_mb: req.max_ram_mb,
         created_at: chrono::Utc::now().to_rfc3339(),
         jar_name,
+        auto_restart: req.auto_restart,
+        jvm_flags: req.jvm_flags,
     };
 
     let json = serde_json::to_string_pretty(&config).map_err(|e| e.to_string())?;
@@ -802,11 +817,14 @@ pub async fn start_server(
 
     let mut child = cmd.spawn().map_err(|e| format!("failed to spawn Java: {}", e))?;
 
+    let child_pid = child.id();
     let stdin = Arc::new(Mutex::new(child.stdin.take()));
     let stdout = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
     let status = Arc::new(std::sync::Mutex::new(ServerStatus::Starting));
     let players = Arc::new(std::sync::Mutex::new((0u32, 20u32)));
+    let pid_arc = Arc::new(std::sync::Mutex::new(child_pid));
+    let stopping_arc = Arc::new(std::sync::Mutex::new(false));
 
     {
         let mut processes = state.processes.lock().await;
@@ -816,6 +834,8 @@ pub async fn start_server(
                 stdin: stdin.clone(),
                 status: status.clone(),
                 players: players.clone(),
+                pid: pid_arc.clone(),
+                stopping: stopping_arc.clone(),
             },
         );
     }
@@ -837,7 +857,9 @@ pub async fn start_server(
     let app_c = app_handle.clone();
     let status_c = status.clone();
     let players_c = players.clone();
+    let stopping_c = stopping_arc.clone();
     let procs_arc = Arc::clone(&state.processes);
+    let config_path_c = state.config_path(&id);
 
     tokio::spawn(async move {
         let mut reader = BufReader::new(stdout).lines();
@@ -875,6 +897,7 @@ pub async fn start_server(
         }
 
         // stdout closed — process exited
+        let was_stopping = *stopping_c.lock().unwrap();
         {
             let mut st = status_c.lock().unwrap();
             *st = ServerStatus::Stopped;
@@ -894,6 +917,22 @@ pub async fn start_server(
                 },
             )
             .ok();
+
+        // Auto-restart if crash (not intentional stop)
+        if !was_stopping {
+            if let Ok(raw) = tokio::fs::read_to_string(&config_path_c).await {
+                if let Ok(cfg) = serde_json::from_str::<ServerConfig>(&raw) {
+                    if cfg.auto_restart {
+                        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                        app_c.emit("server-log", &LogEvent {
+                            server_id: id_c.clone(),
+                            line: "[Launchstone] Server crashed — auto-restarting in 5s...".to_string(),
+                            level: "WARN".to_string(),
+                        }).ok();
+                    }
+                }
+            }
+        }
     });
 
     // Spawn task for stderr (emit as WARN level)
@@ -920,6 +959,79 @@ pub async fn start_server(
         let _ = child.wait().await;
     });
 
+    // Scheduled task runner — polls every 60s while server is running
+    let id_sched = id.clone();
+    let app_sched = app_handle.clone();
+    let procs_sched = Arc::clone(&state.processes);
+    let server_dir_sched = state.server_dir(&id);
+    let stdin_sched = stdin.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
+            let is_running = {
+                let procs = procs_sched.lock().await;
+                if let Some(proc) = procs.get(&id_sched) {
+                    proc.status.lock().unwrap().clone() == ServerStatus::Running
+                } else {
+                    false
+                }
+            };
+            if !is_running { break; }
+
+            let tasks_path = server_dir_sched.join("launchstone_tasks.json");
+            let Ok(raw) = tokio::fs::read_to_string(&tasks_path).await else { continue; };
+            let Ok(mut tasks) = serde_json::from_str::<Vec<ScheduledTask>>(&raw) else { continue; };
+            let now = chrono::Utc::now();
+            let mut changed = false;
+
+            for task in tasks.iter_mut() {
+                if !task.enabled { continue; }
+                let should_run = if let Some(ref last) = task.last_run {
+                    if let Ok(last_dt) = chrono::DateTime::parse_from_rfc3339(last) {
+                        let elapsed = now.signed_duration_since(last_dt.with_timezone(&chrono::Utc));
+                        elapsed.num_minutes() >= task.interval_minutes as i64
+                    } else { true }
+                } else { true };
+
+                if should_run {
+                    task.last_run = Some(now.to_rfc3339());
+                    changed = true;
+                    match &task.action {
+                        ScheduledAction::Command { command } => {
+                            let cmd = format!("{}\n", command);
+                            let mut guard = stdin_sched.lock().await;
+                            if let Some(ref mut s) = *guard {
+                                let _ = s.write_all(cmd.as_bytes()).await;
+                            }
+                            app_sched.emit("server-log", &LogEvent {
+                                server_id: id_sched.clone(),
+                                line: format!("[Scheduler] Ran: {}", command),
+                                level: "INFO".to_string(),
+                            }).ok();
+                        }
+                        ScheduledAction::Restart => {
+                            app_sched.emit("server-log", &LogEvent {
+                                server_id: id_sched.clone(),
+                                line: "[Scheduler] Triggering scheduled restart...".to_string(),
+                                level: "WARN".to_string(),
+                            }).ok();
+                            let mut guard = stdin_sched.lock().await;
+                            if let Some(ref mut s) = *guard {
+                                let _ = s.write_all(b"stop\n").await;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if changed {
+                if let Ok(json) = serde_json::to_string_pretty(&tasks) {
+                    let _ = tokio::fs::write(&tasks_path, json).await;
+                }
+            }
+        }
+    });
+
     Ok(())
 }
 
@@ -933,6 +1045,10 @@ pub async fn stop_server(
         {
             let mut st = proc.status.lock().unwrap();
             *st = ServerStatus::Stopping;
+        }
+        {
+            let mut stopping = proc.stopping.lock().unwrap();
+            *stopping = true;
         }
         let mut stdin_guard = proc.stdin.lock().await;
         if let Some(ref mut stdin) = *stdin_guard {
@@ -1309,4 +1425,487 @@ pub async fn open_server_file(
         .opener()
         .open_path(canonical_target.to_string_lossy(), None::<&str>)
         .map_err(|e| e.to_string())
+}
+
+// ─── resource monitor ─────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn get_server_resources(
+    id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<ResourceUsage, String> {
+    use sysinfo::{Pid, ProcessesToUpdate};
+
+    let pid_opt = {
+        let procs = state.processes.lock().await;
+        procs.get(&id).and_then(|p| *p.pid.lock().unwrap())
+    };
+    let Some(pid) = pid_opt else {
+        return Ok(ResourceUsage { cpu_percent: 0.0, ram_mb: 0 });
+    };
+
+    let (cpu, ram_mb) = {
+        let mut sys = state.sys.lock().unwrap();
+        sys.refresh_processes(ProcessesToUpdate::Some(&[Pid::from(pid as usize)]), true);
+        if let Some(proc) = sys.process(Pid::from(pid as usize)) {
+            (proc.cpu_usage(), proc.memory() / 1024 / 1024)
+        } else {
+            (0.0, 0)
+        }
+    };
+
+    Ok(ResourceUsage { cpu_percent: cpu, ram_mb })
+}
+
+// ─── backups ──────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn list_backups(
+    id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<BackupInfo>, String> {
+    let backups_dir = state.backups_dir(&id);
+    if !backups_dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut rd = tokio::fs::read_dir(&backups_dir).await.map_err(|e| e.to_string())?;
+    let mut result = Vec::new();
+    while let Ok(Some(entry)) = rd.next_entry().await {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.ends_with(".zip") { continue; }
+        let meta = entry.metadata().await.map_err(|e| e.to_string())?;
+        let created_at = meta.modified().ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .and_then(|d| {
+                use chrono::TimeZone;
+                chrono::Utc.timestamp_opt(d.as_secs() as i64, 0).single()
+            })
+            .map(|dt| dt.to_rfc3339())
+            .unwrap_or_default();
+        result.push(BackupInfo { name, size: meta.len(), created_at });
+    }
+    result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn create_backup(
+    id: String,
+    label: Option<String>,
+    state: tauri::State<'_, AppState>,
+    app_handle: AppHandle,
+) -> Result<BackupInfo, String> {
+    let server_dir = state.server_dir(&id);
+    if !server_dir.exists() {
+        return Err("server directory not found".to_string());
+    }
+    let backups_dir = state.backups_dir(&id);
+    tokio::fs::create_dir_all(&backups_dir).await.map_err(|e| e.to_string())?;
+
+    let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string();
+    let name = if let Some(l) = label.filter(|s| !s.is_empty()) {
+        format!("{}-{}.zip", timestamp, l.replace(' ', "_"))
+    } else {
+        format!("{}.zip", timestamp)
+    };
+    let dest = backups_dir.join(&name);
+
+    app_handle.emit("backup-progress", serde_json::json!({
+        "server_id": id, "message": "Creating backup..."
+    })).ok();
+
+    let server_dir_c = server_dir.clone();
+    let dest_c = dest.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let file = std::fs::File::create(&dest_c).map_err(|e| e.to_string())?;
+        let mut zip = zip::ZipWriter::new(file);
+        let opts = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        zip_dir_recursive(&mut zip, &server_dir_c, &server_dir_c, opts)
+            .map_err(|e| e.to_string())?;
+        zip.finish().map_err(|e| e.to_string())?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+    .map_err(|e| e)?;
+
+    let meta = tokio::fs::metadata(&dest).await.map_err(|e| e.to_string())?;
+    let created_at = chrono::Utc::now().to_rfc3339();
+    app_handle.emit("backup-progress", serde_json::json!({
+        "server_id": id, "message": "Backup complete"
+    })).ok();
+
+    Ok(BackupInfo { name, size: meta.len(), created_at })
+}
+
+fn zip_dir_recursive<W: std::io::Write + std::io::Seek>(
+    zip: &mut zip::ZipWriter<W>,
+    dir: &Path,
+    base: &Path,
+    opts: zip::write::SimpleFileOptions,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let rel = path.strip_prefix(base)?;
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
+        if path.is_dir() {
+            zip.add_directory(&format!("{}/", rel_str), opts)?;
+            zip_dir_recursive(zip, &path, base, opts)?;
+        } else {
+            zip.start_file(&rel_str, opts)?;
+            let mut f = std::fs::File::open(&path)?;
+            std::io::copy(&mut f, zip)?;
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn delete_backup(
+    id: String,
+    name: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let path = state.backups_dir(&id).join(&name);
+    if !path.extension().map(|e| e == "zip").unwrap_or(false) {
+        return Err("invalid backup name".to_string());
+    }
+    tokio::fs::remove_file(&path).await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn restore_backup(
+    id: String,
+    name: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    // Server must not be running
+    {
+        let procs = state.processes.lock().await;
+        if let Some(p) = procs.get(&id) {
+            let st = p.status.lock().unwrap().clone();
+            if st == ServerStatus::Running || st == ServerStatus::Starting {
+                return Err("Stop the server before restoring a backup".to_string());
+            }
+        }
+    }
+
+    let backup_path = state.backups_dir(&id).join(&name);
+    if !backup_path.extension().map(|e| e == "zip").unwrap_or(false) {
+        return Err("invalid backup name".to_string());
+    }
+    let server_dir = state.server_dir(&id);
+
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let file = std::fs::File::open(&backup_path).map_err(|e| e.to_string())?;
+        let mut archive = zip::ZipArchive::new(file).map_err(|e| e.to_string())?;
+        archive.extract(&server_dir).map_err(|e| e.to_string())?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+// ─── server properties ────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn get_server_properties(
+    id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<PropertyEntry>, String> {
+    let path = state.server_dir(&id).join("server.properties");
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let content = tokio::fs::read_to_string(&path).await.map_err(|e| e.to_string())?;
+    let mut result = Vec::new();
+    let mut pending_comment: Option<String> = None;
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with('#') {
+            pending_comment = Some(line.trim_start_matches('#').trim().to_string());
+        } else if let Some(eq) = line.find('=') {
+            let key = line[..eq].trim().to_string();
+            let value = line[eq + 1..].trim().to_string();
+            if !key.is_empty() {
+                result.push(PropertyEntry { key, value, comment: pending_comment.take() });
+            }
+        } else {
+            pending_comment = None;
+        }
+    }
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn save_server_properties(
+    id: String,
+    props: Vec<PropertyEntry>,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let path = state.server_dir(&id).join("server.properties");
+    let mut content = String::from("#Minecraft server properties\n");
+    content.push_str(&format!("#{}\n", chrono::Utc::now().to_rfc3339()));
+    for p in &props {
+        if let Some(ref c) = p.comment {
+            content.push_str(&format!("# {}\n", c));
+        }
+        content.push_str(&format!("{}={}\n", p.key, p.value));
+    }
+    tokio::fs::write(&path, content).await.map_err(|e| e.to_string())
+}
+
+// ─── player lists ─────────────────────────────────────────────────────────────
+
+fn player_list_filename(list_type: &str) -> Result<&'static str, String> {
+    match list_type {
+        "whitelist" => Ok("whitelist.json"),
+        "ops" => Ok("ops.json"),
+        "banlist" => Ok("banned-players.json"),
+        _ => Err(format!("unknown list type: {}", list_type)),
+    }
+}
+
+#[tauri::command]
+pub async fn get_player_list(
+    id: String,
+    list_type: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<PlayerListEntry>, String> {
+    let filename = player_list_filename(&list_type)?;
+    let path = state.server_dir(&id).join(filename);
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let raw = tokio::fs::read_to_string(&path).await.map_err(|e| e.to_string())?;
+    let entries: Vec<serde_json::Value> = serde_json::from_str(&raw).unwrap_or_default();
+    let result = entries.iter().filter_map(|v| {
+        let uuid = v["uuid"].as_str()?.to_string();
+        let name = v["name"].as_str()?.to_string();
+        let level = v["level"].as_u64().map(|l| l as u32);
+        let reason = v["reason"].as_str().map(String::from);
+        let expires = v["expires"].as_str().map(String::from);
+        Some(PlayerListEntry { uuid, name, level, reason, expires })
+    }).collect();
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn add_to_player_list(
+    id: String,
+    list_type: String,
+    username: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let filename = player_list_filename(&list_type)?;
+    let path = state.server_dir(&id).join(filename);
+
+    // Fetch UUID from Mojang
+    let mojang_url = format!("https://api.mojang.com/users/profiles/minecraft/{}", username);
+    let resp = reqwest::get(&mojang_url).await.map_err(|e| e.to_string())?;
+    let (uuid, real_name) = if resp.status().is_success() {
+        let data: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
+        let raw_id = data["id"].as_str().unwrap_or("").to_string();
+        let formatted = if raw_id.len() == 32 {
+            format!("{}-{}-{}-{}-{}", &raw_id[0..8], &raw_id[8..12], &raw_id[12..16], &raw_id[16..20], &raw_id[20..])
+        } else { raw_id };
+        (formatted, data["name"].as_str().unwrap_or(&username).to_string())
+    } else {
+        (format!("offline-{}", username), username.clone())
+    };
+
+    let mut entries: Vec<serde_json::Value> = if path.exists() {
+        let raw = tokio::fs::read_to_string(&path).await.map_err(|e| e.to_string())?;
+        serde_json::from_str(&raw).unwrap_or_default()
+    } else { vec![] };
+
+    // Avoid duplicates
+    if entries.iter().any(|e| e["name"].as_str() == Some(&real_name)) {
+        return Ok(());
+    }
+
+    let entry = match list_type.as_str() {
+        "ops" => serde_json::json!({ "uuid": uuid, "name": real_name, "level": 4, "bypassesPlayerLimit": false }),
+        "banlist" => serde_json::json!({ "uuid": uuid, "name": real_name, "created": chrono::Utc::now().to_rfc3339(), "source": "Launchstone", "expires": "forever", "reason": "Banned by an operator." }),
+        _ => serde_json::json!({ "uuid": uuid, "name": real_name }),
+    };
+    entries.push(entry);
+
+    let json = serde_json::to_string_pretty(&entries).map_err(|e| e.to_string())?;
+    tokio::fs::write(&path, json).await.map_err(|e| e.to_string())?;
+
+    // Send runtime command if server is running
+    let runtime_cmd = match list_type.as_str() {
+        "whitelist" => Some(format!("whitelist add {}", real_name)),
+        "ops" => Some(format!("op {}", real_name)),
+        "banlist" => Some(format!("ban {}", real_name)),
+        _ => None,
+    };
+    if let Some(cmd) = runtime_cmd {
+        let procs = state.processes.lock().await;
+        if let Some(proc) = procs.get(&id) {
+            let mut stdin_guard = proc.stdin.lock().await;
+            if let Some(ref mut stdin) = *stdin_guard {
+                let _ = stdin.write_all(format!("{}\n", cmd).as_bytes()).await;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn remove_from_player_list(
+    id: String,
+    list_type: String,
+    uuid: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let filename = player_list_filename(&list_type)?;
+    let path = state.server_dir(&id).join(filename);
+    if !path.exists() { return Ok(()); }
+
+    let raw = tokio::fs::read_to_string(&path).await.map_err(|e| e.to_string())?;
+    let mut entries: Vec<serde_json::Value> = serde_json::from_str(&raw).unwrap_or_default();
+    let removed_name = entries.iter().find(|e| e["uuid"].as_str() == Some(&uuid))
+        .and_then(|e| e["name"].as_str().map(String::from));
+    entries.retain(|e| e["uuid"].as_str() != Some(&uuid));
+
+    let json = serde_json::to_string_pretty(&entries).map_err(|e| e.to_string())?;
+    tokio::fs::write(&path, json).await.map_err(|e| e.to_string())?;
+
+    if let Some(name) = removed_name {
+        let runtime_cmd = match list_type.as_str() {
+            "whitelist" => Some(format!("whitelist remove {}", name)),
+            "ops" => Some(format!("deop {}", name)),
+            "banlist" => Some(format!("pardon {}", name)),
+            _ => None,
+        };
+        if let Some(cmd) = runtime_cmd {
+            let procs = state.processes.lock().await;
+            if let Some(proc) = procs.get(&id) {
+                let mut stdin_guard = proc.stdin.lock().await;
+                if let Some(ref mut stdin) = *stdin_guard {
+                    let _ = stdin.write_all(format!("{}\n", cmd).as_bytes()).await;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// ─── file upload ──────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn upload_server_file(
+    id: String,
+    path: String,
+    content_b64: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    use base64::Engine;
+    let server_dir = state.server_dir(&id);
+    let file_path = server_dir.join(&path);
+    let canonical_server = server_dir.canonicalize().map_err(|e| e.to_string())?;
+    let parent = file_path.parent().ok_or("invalid path")?;
+    tokio::fs::create_dir_all(parent).await.map_err(|e| e.to_string())?;
+    let canonical_parent = parent.canonicalize().map_err(|e| e.to_string())?;
+    if !canonical_parent.starts_with(&canonical_server) {
+        return Err("path traversal not allowed".to_string());
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(&content_b64)
+        .map_err(|e| e.to_string())?;
+    tokio::fs::write(&file_path, bytes).await.map_err(|e| e.to_string())
+}
+
+// ─── scheduled tasks ──────────────────────────────────────────────────────────
+
+fn tasks_path_for(server_dir: &Path) -> std::path::PathBuf {
+    server_dir.join("launchstone_tasks.json")
+}
+
+async fn load_tasks(server_dir: &Path) -> Vec<ScheduledTask> {
+    let p = tasks_path_for(server_dir);
+    if !p.exists() { return vec![]; }
+    let raw = tokio::fs::read_to_string(&p).await.unwrap_or_default();
+    serde_json::from_str(&raw).unwrap_or_default()
+}
+
+async fn save_tasks(server_dir: &Path, tasks: &Vec<ScheduledTask>) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(tasks).map_err(|e| e.to_string())?;
+    tokio::fs::write(tasks_path_for(server_dir), json).await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_scheduled_tasks(
+    id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<ScheduledTask>, String> {
+    Ok(load_tasks(&state.server_dir(&id)).await)
+}
+
+#[tauri::command]
+pub async fn add_scheduled_task(
+    id: String,
+    task: ScheduledTask,
+    state: tauri::State<'_, AppState>,
+) -> Result<ScheduledTask, String> {
+    let server_dir = state.server_dir(&id);
+    let mut tasks = load_tasks(&server_dir).await;
+    let new_task = ScheduledTask {
+        id: uuid::Uuid::new_v4().to_string(),
+        last_run: None,
+        ..task
+    };
+    tasks.push(new_task.clone());
+    save_tasks(&server_dir, &tasks).await?;
+    Ok(new_task)
+}
+
+#[tauri::command]
+pub async fn update_scheduled_task(
+    id: String,
+    task: ScheduledTask,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let server_dir = state.server_dir(&id);
+    let mut tasks = load_tasks(&server_dir).await;
+    if let Some(t) = tasks.iter_mut().find(|t| t.id == task.id) {
+        *t = task;
+    }
+    save_tasks(&server_dir, &tasks).await
+}
+
+#[tauri::command]
+pub async fn remove_scheduled_task(
+    id: String,
+    task_id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let server_dir = state.server_dir(&id);
+    let mut tasks = load_tasks(&server_dir).await;
+    tasks.retain(|t| t.id != task_id);
+    save_tasks(&server_dir, &tasks).await
+}
+
+// ─── server config update ─────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn update_server(
+    id: String,
+    req: UpdateServerRequest,
+    state: tauri::State<'_, AppState>,
+) -> Result<ServerConfig, String> {
+    let config_path = state.config_path(&id);
+    let raw = tokio::fs::read_to_string(&config_path).await.map_err(|e| e.to_string())?;
+    let mut config: ServerConfig = serde_json::from_str(&raw).map_err(|e| e.to_string())?;
+    config.name = req.name;
+    config.max_ram_mb = req.max_ram_mb;
+    config.auto_restart = req.auto_restart;
+    config.jvm_flags = req.jvm_flags;
+    let json = serde_json::to_string_pretty(&config).map_err(|e| e.to_string())?;
+    tokio::fs::write(&config_path, json).await.map_err(|e| e.to_string())?;
+    Ok(config)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,23 @@ pub fn run() {
             commands::save_settings,
             commands::get_data_dir,
             commands::open_path,
+            // new
+            commands::get_server_resources,
+            commands::list_backups,
+            commands::create_backup,
+            commands::delete_backup,
+            commands::restore_backup,
+            commands::get_server_properties,
+            commands::save_server_properties,
+            commands::get_player_list,
+            commands::add_to_player_list,
+            commands::remove_from_player_list,
+            commands::upload_server_file,
+            commands::get_scheduled_tasks,
+            commands::add_scheduled_task,
+            commands::update_scheduled_task,
+            commands::remove_scheduled_task,
+            commands::update_server,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -49,6 +49,10 @@ pub struct ServerConfig {
     pub max_ram_mb: u32,
     pub created_at: String,
     pub jar_name: String,
+    #[serde(default)]
+    pub auto_restart: bool,
+    #[serde(default)]
+    pub jvm_flags: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -67,6 +71,18 @@ pub struct CreateServerRequest {
     pub minecraft_version: String,
     pub port: u16,
     pub max_ram_mb: u32,
+    #[serde(default)]
+    pub auto_restart: bool,
+    #[serde(default)]
+    pub jvm_flags: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateServerRequest {
+    pub name: String,
+    pub max_ram_mb: u32,
+    pub auto_restart: bool,
+    pub jvm_flags: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -118,4 +134,55 @@ pub struct FileEntry {
     pub is_dir: bool,
     pub size: u64,
     pub modified: String,
+}
+
+// ─── new types ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupInfo {
+    pub name: String,
+    pub size: u64,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ScheduledAction {
+    Command { command: String },
+    Restart,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduledTask {
+    pub id: String,
+    pub label: String,
+    pub interval_minutes: u32,
+    pub action: ScheduledAction,
+    pub enabled: bool,
+    pub last_run: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ResourceUsage {
+    pub cpu_percent: f32,
+    pub ram_mb: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlayerListEntry {
+    pub uuid: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub level: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PropertyEntry {
+    pub key: String,
+    pub value: String,
+    pub comment: Option<String>,
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8,11 +8,14 @@ pub struct ProcessHandle {
     pub stdin: Arc<Mutex<Option<ChildStdin>>>,
     pub status: Arc<std::sync::Mutex<ServerStatus>>,
     pub players: Arc<std::sync::Mutex<(u32, u32)>>,
+    pub pid: Arc<std::sync::Mutex<Option<u32>>>,
+    pub stopping: Arc<std::sync::Mutex<bool>>,
 }
 
 pub struct AppState {
     pub processes: Arc<Mutex<HashMap<String, ProcessHandle>>>,
     pub data_dir: PathBuf,
+    pub sys: Arc<std::sync::Mutex<sysinfo::System>>,
 }
 
 impl AppState {
@@ -20,6 +23,7 @@ impl AppState {
         Self {
             processes: Arc::new(Mutex::new(HashMap::new())),
             data_dir,
+            sys: Arc::new(std::sync::Mutex::new(sysinfo::System::new())),
         }
     }
 
@@ -37,5 +41,9 @@ impl AppState {
 
     pub fn settings_path(&self) -> PathBuf {
         self.data_dir.join("settings.json")
+    }
+
+    pub fn backups_dir(&self, id: &str) -> PathBuf {
+        self.data_dir.join("backups").join(id)
     }
 }

--- a/src/components/BackupManager.tsx
+++ b/src/components/BackupManager.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from "react";
+import { Archive, Download, RefreshCw, Trash2, UploadCloud } from "lucide-react";
+import type { BackupInfo } from "../types";
+import { createBackup, deleteBackup, listBackups, restoreBackup } from "../lib/tauri";
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string) {
+  try { return new Date(iso).toLocaleString(); } catch { return iso; }
+}
+
+export default function BackupManager({ serverId }: { serverId: string }) {
+  const [backups, setBackups] = useState<BackupInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [label, setLabel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [confirmRestore, setConfirmRestore] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    try { setBackups(await listBackups(serverId)); }
+    catch (e) { setError(String(e)); }
+    finally { setLoading(false); }
+  }
+
+  useEffect(() => { load(); }, [serverId]);
+
+  async function handleCreate() {
+    setCreating(true);
+    setError(null);
+    try {
+      await createBackup(serverId, label || undefined);
+      setLabel("");
+      await load();
+    } catch (e) { setError(String(e)); }
+    finally { setCreating(false); }
+  }
+
+  async function handleRestore(name: string) {
+    setError(null);
+    try { await restoreBackup(serverId, name); setConfirmRestore(null); }
+    catch (e) { setError(String(e)); setConfirmRestore(null); }
+  }
+
+  async function handleDelete(name: string) {
+    try { await deleteBackup(serverId, name); setConfirmDelete(null); await load(); }
+    catch (e) { setError(String(e)); setConfirmDelete(null); }
+  }
+
+  return (
+    <div style={{ padding: "20px 28px", display: "flex", flexDirection: "column", gap: 20 }}>
+      {/* Create backup */}
+      <div style={{ background: "var(--color-surface-1)", border: "1px solid var(--color-border)", borderRadius: 10, padding: 16 }}>
+        <div style={{ fontWeight: 600, fontSize: 14, marginBottom: 12 }}>Create Backup</div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <input
+            value={label}
+            onChange={e => setLabel(e.target.value)}
+            placeholder="Label (optional)"
+            style={{ flex: 1, padding: "8px 12px", borderRadius: 7, border: "1px solid var(--color-border)", background: "var(--color-surface-2)", color: "var(--color-text-primary)", fontSize: 13, fontFamily: "inherit", outline: "none" }}
+          />
+          <button
+            onClick={handleCreate}
+            disabled={creating}
+            style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 16px", border: "none", borderRadius: 7, background: "var(--color-orange-primary)", color: "#fff", fontSize: 13, fontWeight: 600, cursor: creating ? "not-allowed" : "pointer", fontFamily: "inherit", opacity: creating ? 0.6 : 1 }}
+          >
+            <UploadCloud size={14} />
+            {creating ? "Creating…" : "Create Backup"}
+          </button>
+        </div>
+        {error && <p style={{ marginTop: 10, fontSize: 12, color: "#ef4444" }}>{error}</p>}
+      </div>
+
+      {/* List */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ fontWeight: 600, fontSize: 14 }}>Saved Backups</span>
+        <button onClick={load} style={{ display: "flex", alignItems: "center", gap: 5, padding: "6px 10px", border: "1px solid var(--color-border)", borderRadius: 6, background: "transparent", color: "var(--color-text-secondary)", fontSize: 12, cursor: "pointer", fontFamily: "inherit" }}>
+          <RefreshCw size={12} /> Refresh
+        </button>
+      </div>
+
+      {loading ? (
+        <p style={{ color: "var(--color-text-muted)", fontSize: 13 }}>Loading…</p>
+      ) : backups.length === 0 ? (
+        <div style={{ textAlign: "center", padding: "40px 0", color: "var(--color-text-muted)" }}>
+          <Archive size={36} strokeWidth={1} style={{ margin: "0 auto 10px" }} />
+          <p style={{ margin: 0, fontSize: 14 }}>No backups yet</p>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {backups.map(b => (
+            <div key={b.name} style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 14px", borderRadius: 8, background: "var(--color-surface-1)", border: "1px solid var(--color-border)" }}>
+              <Archive size={16} color="var(--color-text-muted)" style={{ flexShrink: 0 }} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontWeight: 500, fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{b.name}</div>
+                <div style={{ fontSize: 11, color: "var(--color-text-muted)" }}>{formatDate(b.created_at)} · {formatBytes(b.size)}</div>
+              </div>
+              <div style={{ display: "flex", gap: 6 }}>
+                <button onClick={() => setConfirmRestore(b.name)} title="Restore" style={{ display: "flex", alignItems: "center", gap: 5, padding: "6px 10px", border: "1px solid var(--color-border)", borderRadius: 6, background: "transparent", color: "var(--color-text-secondary)", fontSize: 12, cursor: "pointer", fontFamily: "inherit" }}>
+                  <Download size={13} /> Restore
+                </button>
+                <button onClick={() => setConfirmDelete(b.name)} title="Delete" style={{ display: "flex", alignItems: "center", padding: "6px 8px", border: "1px solid var(--color-border)", borderRadius: 6, background: "transparent", color: "#ef4444", cursor: "pointer" }}>
+                  <Trash2 size={13} />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Restore confirm */}
+      {confirmRestore && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 50 }}>
+          <div style={{ background: "var(--color-surface-1)", border: "1px solid var(--color-border)", borderRadius: 12, padding: 24, maxWidth: 380, width: "90%" }}>
+            <div style={{ fontWeight: 700, fontSize: 15, marginBottom: 10 }}>Restore Backup?</div>
+            <p style={{ fontSize: 13, color: "var(--color-text-muted)", margin: "0 0 20px" }}>This will overwrite current server files with <strong>{confirmRestore}</strong>. The server must be stopped.</p>
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+              <button onClick={() => setConfirmRestore(null)} style={{ padding: "8px 14px", border: "1px solid var(--color-border)", borderRadius: 7, background: "transparent", color: "var(--color-text-secondary)", fontSize: 13, cursor: "pointer", fontFamily: "inherit" }}>Cancel</button>
+              <button onClick={() => handleRestore(confirmRestore)} style={{ padding: "8px 14px", border: "none", borderRadius: 7, background: "var(--color-orange-primary)", color: "#fff", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit" }}>Restore</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete confirm */}
+      {confirmDelete && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 50 }}>
+          <div style={{ background: "var(--color-surface-1)", border: "1px solid var(--color-border)", borderRadius: 12, padding: 24, maxWidth: 380, width: "90%" }}>
+            <div style={{ fontWeight: 700, fontSize: 15, marginBottom: 10 }}>Delete Backup?</div>
+            <p style={{ fontSize: 13, color: "var(--color-text-muted)", margin: "0 0 20px" }}>This will permanently delete <strong>{confirmDelete}</strong>.</p>
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+              <button onClick={() => setConfirmDelete(null)} style={{ padding: "8px 14px", border: "1px solid var(--color-border)", borderRadius: 7, background: "transparent", color: "var(--color-text-secondary)", fontSize: 13, cursor: "pointer", fontFamily: "inherit" }}>Cancel</button>
+              <button onClick={() => handleDelete(confirmDelete)} style={{ padding: "8px 14px", border: "none", borderRadius: 7, background: "#ef4444", color: "#fff", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit" }}>Delete</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/CreateServerModal.tsx
+++ b/src/components/CreateServerModal.tsx
@@ -79,6 +79,8 @@ export default function CreateServerModal({ onClose, onCreated }: Props) {
         minecraft_version: selectedVersion,
         port,
         max_ram_mb: ram,
+        auto_restart: false,
+        jvm_flags: "",
       };
       await createServer(req);
       onCreated();

--- a/src/components/FileManager.tsx
+++ b/src/components/FileManager.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ArrowLeft,
   ChevronRight,
@@ -10,6 +10,7 @@ import {
   RefreshCw,
   Save,
   Trash2,
+  Upload,
   X,
 } from "lucide-react";
 import type { FileEntry } from "../types";
@@ -18,6 +19,7 @@ import {
   listServerFiles,
   openServerFile,
   readServerFile,
+  uploadServerFile,
   writeServerFile,
 } from "../lib/tauri";
 
@@ -224,6 +226,8 @@ export default function FileManager({ serverId }: Props) {
   const [loading, setLoading] = useState(true);
   const [editingEntry, setEditingEntry] = useState<FileEntry | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<FileEntry | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const uploadRef = useRef<HTMLInputElement>(null);
 
   const subpath = pathParts.length > 0 ? pathParts.join("/") : null;
 
@@ -251,6 +255,19 @@ export default function FileManager({ serverId }: Props) {
     } else {
       openServerFile(serverId, entry.path).catch(console.error);
     }
+  }
+
+  async function handleUpload(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    setUploading(true);
+    for (const file of Array.from(files)) {
+      const bytes = await file.arrayBuffer();
+      const b64 = btoa(String.fromCharCode(...new Uint8Array(bytes)));
+      const destPath = subpath ? `${subpath}/${file.name}` : file.name;
+      await uploadServerFile(serverId, destPath, b64).catch(console.error);
+    }
+    setUploading(false);
+    refresh();
   }
 
   async function handleDelete(entry: FileEntry) {
@@ -363,6 +380,22 @@ export default function FileManager({ serverId }: Props) {
           <RefreshCw size={12} />
           Refresh
         </button>
+
+        <button
+          onClick={() => uploadRef.current?.click()}
+          disabled={uploading}
+          style={{ display: "flex", alignItems: "center", gap: 6, padding: "6px 10px", border: "1px solid var(--color-border)", borderRadius: 7, background: "transparent", color: "var(--color-text-secondary)", fontSize: 12, fontWeight: 500, cursor: "pointer", fontFamily: "inherit", opacity: uploading ? 0.6 : 1 }}
+        >
+          <Upload size={12} />
+          {uploading ? "Uploading…" : "Upload"}
+        </button>
+        <input
+          ref={uploadRef}
+          type="file"
+          multiple
+          style={{ display: "none" }}
+          onChange={e => handleUpload(e.target.files)}
+        />
 
         <button
           onClick={() => openServerFile(serverId, subpath).catch(console.error)}

--- a/src/components/PlayerListManager.tsx
+++ b/src/components/PlayerListManager.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from "react";
+import { Plus, RefreshCw, Shield, Trash2, UserX } from "lucide-react";
+import type { PlayerListEntry } from "../types";
+import { addToPlayerList, getPlayerList, removeFromPlayerList } from "../lib/tauri";
+
+type ListType = "whitelist" | "ops" | "banlist";
+
+const LIST_META: Record<ListType, { label: string; icon: React.ReactNode; color: string; emptyMsg: string }> = {
+  whitelist: { label: "Whitelist", icon: <Shield size={14} />, color: "#22c55e", emptyMsg: "No whitelisted players" },
+  ops: { label: "Operators", icon: <Shield size={14} />, color: "var(--color-orange-primary)", emptyMsg: "No operators" },
+  banlist: { label: "Banned Players", icon: <UserX size={14} />, color: "#ef4444", emptyMsg: "No banned players" },
+};
+
+export default function PlayerListManager({ serverId }: { serverId: string }) {
+  const [activeList, setActiveList] = useState<ListType>("whitelist");
+  const [entries, setEntries] = useState<PlayerListEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [username, setUsername] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<PlayerListEntry | null>(null);
+
+  async function load(list = activeList) {
+    setLoading(true);
+    setError(null);
+    try { setEntries(await getPlayerList(serverId, list)); }
+    catch (e) { setError(String(e)); }
+    finally { setLoading(false); }
+  }
+
+  useEffect(() => { load(activeList); }, [serverId, activeList]);
+
+  async function handleAdd() {
+    if (!username.trim()) return;
+    setAdding(true);
+    setError(null);
+    try {
+      await addToPlayerList(serverId, activeList, username.trim());
+      setUsername("");
+      await load();
+    } catch (e) { setError(String(e)); }
+    finally { setAdding(false); }
+  }
+
+  async function handleRemove(entry: PlayerListEntry) {
+    setError(null);
+    try {
+      await removeFromPlayerList(serverId, activeList, entry.uuid);
+      setConfirmRemove(null);
+      await load();
+    } catch (e) { setError(String(e)); setConfirmRemove(null); }
+  }
+
+  const inputStyle = { padding: "8px 12px", borderRadius: 7, border: "1px solid var(--color-border)", background: "var(--color-surface-2)", color: "var(--color-text-primary)", fontSize: 13, fontFamily: "inherit", outline: "none" };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      {/* Sub-tabs */}
+      <div style={{ display: "flex", gap: 2, padding: "0 28px", borderBottom: "1px solid var(--color-border)", flexShrink: 0 }}>
+        {(["whitelist", "ops", "banlist"] as ListType[]).map(lt => {
+          const meta = LIST_META[lt];
+          return (
+            <button
+              key={lt}
+              onClick={() => setActiveList(lt)}
+              style={{ display: "flex", alignItems: "center", gap: 6, padding: "10px 14px", border: "none", borderBottom: activeList === lt ? `2px solid ${meta.color}` : "2px solid transparent", background: "transparent", color: activeList === lt ? meta.color : "var(--color-text-muted)", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit", marginBottom: -1 }}
+            >
+              {meta.icon}
+              {meta.label}
+              <span style={{ padding: "1px 6px", borderRadius: 99, fontSize: 11, backgroundColor: "var(--color-surface-3)", color: "var(--color-text-muted)" }}>
+                {entries.length}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={{ flex: 1, overflowY: "auto", padding: "20px 28px", display: "flex", flexDirection: "column", gap: 16 }}>
+        {/* Add player */}
+        <div style={{ display: "flex", gap: 8 }}>
+          <input
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            onKeyDown={e => e.key === "Enter" && handleAdd()}
+            placeholder="Minecraft username…"
+            style={{ ...inputStyle, flex: 1 }}
+          />
+          <button
+            onClick={() => load()}
+            style={{ display: "flex", alignItems: "center", padding: "8px 10px", border: "1px solid var(--color-border)", borderRadius: 7, background: "transparent", color: "var(--color-text-secondary)", cursor: "pointer" }}
+          >
+            <RefreshCw size={13} />
+          </button>
+          <button
+            onClick={handleAdd}
+            disabled={adding || !username.trim()}
+            style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 14px", border: "none", borderRadius: 7, background: LIST_META[activeList].color, color: "#fff", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit", opacity: adding || !username.trim() ? 0.6 : 1 }}
+          >
+            <Plus size={14} />
+            {adding ? "Adding…" : `Add to ${LIST_META[activeList].label}`}
+          </button>
+        </div>
+        {error && <p style={{ fontSize: 12, color: "#ef4444", margin: 0 }}>{error}</p>}
+
+        {loading ? (
+          <p style={{ color: "var(--color-text-muted)", fontSize: 13 }}>Loading…</p>
+        ) : entries.length === 0 ? (
+          <div style={{ textAlign: "center", padding: "40px 0", color: "var(--color-text-muted)" }}>
+            <p style={{ margin: 0, fontSize: 14 }}>{LIST_META[activeList].emptyMsg}</p>
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {entries.map(entry => (
+              <div key={entry.uuid} style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 14px", borderRadius: 8, background: "var(--color-surface-1)", border: "1px solid var(--color-border)" }}>
+                <img
+                  src={`https://mc-heads.net/avatar/${entry.name}/28`}
+                  alt={entry.name}
+                  width={28} height={28}
+                  style={{ borderRadius: 4, imageRendering: "pixelated", flexShrink: 0 }}
+                />
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontWeight: 500, fontSize: 13 }}>{entry.name}</div>
+                  <div style={{ fontSize: 11, color: "var(--color-text-muted)", fontFamily: "monospace" }}>{entry.uuid}</div>
+                  {entry.reason && <div style={{ fontSize: 11, color: "#ef4444" }}>Reason: {entry.reason}</div>}
+                  {entry.level != null && <div style={{ fontSize: 11, color: "var(--color-orange-primary)" }}>Op Level: {entry.level}</div>}
+                </div>
+                <button
+                  onClick={() => setConfirmRemove(entry)}
+                  style={{ display: "flex", alignItems: "center", padding: "6px 8px", border: "1px solid var(--color-border)", borderRadius: 6, background: "transparent", color: "#ef4444", cursor: "pointer" }}
+                >
+                  <Trash2 size={13} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {confirmRemove && (
+        <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 50 }}>
+          <div style={{ background: "var(--color-surface-1)", border: "1px solid var(--color-border)", borderRadius: 12, padding: 24, maxWidth: 360, width: "90%" }}>
+            <div style={{ fontWeight: 700, fontSize: 15, marginBottom: 10 }}>Remove {confirmRemove.name}?</div>
+            <p style={{ fontSize: 13, color: "var(--color-text-muted)", margin: "0 0 20px" }}>
+              Remove <strong>{confirmRemove.name}</strong> from the {LIST_META[activeList].label.toLowerCase()}?
+            </p>
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+              <button onClick={() => setConfirmRemove(null)} style={{ padding: "8px 14px", border: "1px solid var(--color-border)", borderRadius: 7, background: "transparent", color: "var(--color-text-secondary)", fontSize: 13, cursor: "pointer", fontFamily: "inherit" }}>Cancel</button>
+              <button onClick={() => handleRemove(confirmRemove)} style={{ padding: "8px 14px", border: "none", borderRadius: 7, background: "#ef4444", color: "#fff", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit" }}>Remove</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SchedulerManager.tsx
+++ b/src/components/SchedulerManager.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from "react";
+import { Clock, Plus, Trash2, ToggleLeft, ToggleRight } from "lucide-react";
+import type { ScheduledAction, ScheduledTask } from "../types";
+import { addScheduledTask, getScheduledTasks, removeScheduledTask, updateScheduledTask } from "../lib/tauri";
+
+function formatDate(iso: string | null) {
+  if (!iso) return "Never";
+  try { return new Date(iso).toLocaleString(); } catch { return iso; }
+}
+
+export default function SchedulerManager({ serverId }: { serverId: string }) {
+  const [tasks, setTasks] = useState<ScheduledTask[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  // Form state
+  const [label, setLabel] = useState("");
+  const [interval, setInterval] = useState(60);
+  const [actionType, setActionType] = useState<"command" | "restart">("command");
+  const [command, setCommand] = useState("");
+
+  async function load() {
+    setLoading(true);
+    try { setTasks(await getScheduledTasks(serverId)); }
+    catch (e) { setError(String(e)); }
+    finally { setLoading(false); }
+  }
+
+  useEffect(() => { load(); }, [serverId]);
+
+  async function handleAdd() {
+    if (!label.trim()) return;
+    setError(null);
+    const action: ScheduledAction = actionType === "restart"
+      ? { type: "restart" }
+      : { type: "command", command: command.trim() };
+    try {
+      await addScheduledTask(serverId, { label: label.trim(), interval_minutes: interval, action, enabled: true });
+      setLabel(""); setInterval(60); setCommand(""); setShowForm(false);
+      await load();
+    } catch (e) { setError(String(e)); }
+  }
+
+  async function handleToggle(task: ScheduledTask) {
+    try {
+      await updateScheduledTask(serverId, { ...task, enabled: !task.enabled });
+      await load();
+    } catch (e) { setError(String(e)); }
+  }
+
+  async function handleRemove(taskId: string) {
+    try { await removeScheduledTask(serverId, taskId); await load(); }
+    catch (e) { setError(String(e)); }
+  }
+
+  const inputStyle = { padding: "8px 12px", borderRadius: 7, border: "1px solid var(--color-border)", background: "var(--color-surface-2)", color: "var(--color-text-primary)", fontSize: 13, fontFamily: "inherit", outline: "none" };
+
+  return (
+    <div style={{ padding: "20px 28px", display: "flex", flexDirection: "column", gap: 16 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <div>
+          <div style={{ fontWeight: 600, fontSize: 14 }}>Scheduled Tasks</div>
+          <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>Automatically run commands or restart on an interval while the server is running.</div>
+        </div>
+        <button
+          onClick={() => setShowForm(v => !v)}
+          style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 14px", border: "none", borderRadius: 7, background: "var(--color-orange-primary)", color: "#fff", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit" }}
+        >
+          <Plus size={14} /> New Task
+        </button>
+      </div>
+      {error && <p style={{ fontSize: 12, color: "#ef4444", margin: 0 }}>{error}</p>}
+
+      {/* Add task form */}
+      {showForm && (
+        <div style={{ background: "var(--color-surface-1)", border: "1px solid var(--color-border)", borderRadius: 10, padding: 16, display: "flex", flexDirection: "column", gap: 10 }}>
+          <div style={{ fontWeight: 600, fontSize: 13 }}>New Task</div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 140px", gap: 8 }}>
+            <input value={label} onChange={e => setLabel(e.target.value)} placeholder="Task label…" style={inputStyle} />
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <input value={interval} onChange={e => setInterval(Number(e.target.value))} type="number" min={1} style={{ ...inputStyle, width: 60 }} />
+              <span style={{ fontSize: 12, color: "var(--color-text-muted)", whiteSpace: "nowrap" }}>min interval</span>
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            {(["command", "restart"] as const).map(t => (
+              <button
+                key={t}
+                onClick={() => setActionType(t)}
+                style={{ padding: "6px 14px", border: `1px solid ${actionType === t ? "var(--color-orange-primary)" : "var(--color-border)"}`, borderRadius: 6, background: actionType === t ? "var(--color-orange-primary)" : "transparent", color: actionType === t ? "#fff" : "var(--color-text-secondary)", fontSize: 13, cursor: "pointer", fontFamily: "inherit", textTransform: "capitalize" }}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+          {actionType === "command" && (
+            <input value={command} onChange={e => setCommand(e.target.value)} placeholder="Command (without /)…" style={inputStyle} />
+          )}
+          <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+            <button onClick={() => setShowForm(false)} style={{ padding: "7px 14px", border: "1px solid var(--color-border)", borderRadius: 6, background: "transparent", color: "var(--color-text-secondary)", fontSize: 13, cursor: "pointer", fontFamily: "inherit" }}>Cancel</button>
+            <button onClick={handleAdd} disabled={!label.trim()} style={{ padding: "7px 14px", border: "none", borderRadius: 6, background: "var(--color-orange-primary)", color: "#fff", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit", opacity: !label.trim() ? 0.5 : 1 }}>Add Task</button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <p style={{ color: "var(--color-text-muted)", fontSize: 13 }}>Loading…</p>
+      ) : tasks.length === 0 ? (
+        <div style={{ textAlign: "center", padding: "40px 0", color: "var(--color-text-muted)" }}>
+          <Clock size={36} strokeWidth={1} style={{ margin: "0 auto 10px", display: "block" }} />
+          <p style={{ margin: 0, fontSize: 14 }}>No scheduled tasks</p>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {tasks.map(task => (
+            <div key={task.id} style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 14px", borderRadius: 8, background: "var(--color-surface-1)", border: "1px solid var(--color-border)", opacity: task.enabled ? 1 : 0.6 }}>
+              <Clock size={16} color="var(--color-text-muted)" style={{ flexShrink: 0 }} />
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: 500, fontSize: 13 }}>{task.label}</div>
+                <div style={{ fontSize: 11, color: "var(--color-text-muted)" }}>
+                  Every {task.interval_minutes} min ·{" "}
+                  {task.action.type === "restart" ? "Restart server" : `Run: ${(task.action as any).command}`}
+                </div>
+                <div style={{ fontSize: 11, color: "var(--color-text-muted)" }}>Last run: {formatDate(task.last_run)}</div>
+              </div>
+              <button
+                onClick={() => handleToggle(task)}
+                style={{ background: "transparent", border: "none", cursor: "pointer", color: task.enabled ? "var(--color-orange-primary)" : "var(--color-text-muted)", padding: 4 }}
+                title={task.enabled ? "Disable" : "Enable"}
+              >
+                {task.enabled ? <ToggleRight size={22} /> : <ToggleLeft size={22} />}
+              </button>
+              <button
+                onClick={() => handleRemove(task.id)}
+                style={{ display: "flex", alignItems: "center", padding: "6px 8px", border: "1px solid var(--color-border)", borderRadius: 6, background: "transparent", color: "#ef4444", cursor: "pointer" }}
+              >
+                <Trash2 size={13} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ServerPropertiesEditor.tsx
+++ b/src/components/ServerPropertiesEditor.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from "react";
+import { Save } from "lucide-react";
+import type { PropertyEntry } from "../types";
+import { getServerProperties, saveServerProperties } from "../lib/tauri";
+
+// Well-known properties with friendly labels
+const KNOWN: Record<string, { label: string; type: "boolean" | "number" | "text"; description?: string }> = {
+  "server-port": { label: "Server Port", type: "number" },
+  "max-players": { label: "Max Players", type: "number" },
+  "gamemode": { label: "Gamemode", type: "text", description: "survival, creative, adventure, spectator" },
+  "difficulty": { label: "Difficulty", type: "text", description: "peaceful, easy, normal, hard" },
+  "online-mode": { label: "Online Mode", type: "boolean" },
+  "pvp": { label: "PvP", type: "boolean" },
+  "spawn-monsters": { label: "Spawn Monsters", type: "boolean" },
+  "spawn-animals": { label: "Spawn Animals", type: "boolean" },
+  "spawn-npcs": { label: "Spawn NPCs", type: "boolean" },
+  "allow-flight": { label: "Allow Flight", type: "boolean" },
+  "allow-nether": { label: "Allow Nether", type: "boolean" },
+  "enable-command-block": { label: "Command Blocks", type: "boolean" },
+  "force-gamemode": { label: "Force Gamemode", type: "boolean" },
+  "motd": { label: "MOTD", type: "text" },
+  "level-name": { label: "World Name", type: "text" },
+  "level-seed": { label: "World Seed", type: "text" },
+  "level-type": { label: "World Type", type: "text", description: "minecraft:default, minecraft:flat, minecraft:large_biomes, minecraft:amplified" },
+  "view-distance": { label: "View Distance", type: "number" },
+  "simulation-distance": { label: "Simulation Distance", type: "number" },
+  "max-build-height": { label: "Max Build Height", type: "number" },
+  "white-list": { label: "Whitelist", type: "boolean" },
+  "enforce-whitelist": { label: "Enforce Whitelist", type: "boolean" },
+  "enable-rcon": { label: "Enable RCON", type: "boolean" },
+  "rcon.port": { label: "RCON Port", type: "number" },
+  "rcon.password": { label: "RCON Password", type: "text" },
+  "enable-query": { label: "Enable Query", type: "boolean" },
+};
+
+export default function ServerPropertiesEditor({ serverId }: { serverId: string }) {
+  const [props, setProps] = useState<PropertyEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+
+  async function load() {
+    setLoading(true);
+    try { setProps(await getServerProperties(serverId)); }
+    catch (e) { setError(String(e)); }
+    finally { setLoading(false); }
+  }
+
+  useEffect(() => { load(); }, [serverId]);
+
+  function setValue(key: string, val: string) {
+    setProps(prev => prev.map(p => p.key === key ? { ...p, value: val } : p));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      await saveServerProperties(serverId, props);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (e) { setError(String(e)); }
+    finally { setSaving(false); }
+  }
+
+  const filtered = props.filter(p =>
+    !search || p.key.toLowerCase().includes(search.toLowerCase()) ||
+    KNOWN[p.key]?.label.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const knownProps = filtered.filter(p => KNOWN[p.key]);
+  const otherProps = filtered.filter(p => !KNOWN[p.key]);
+
+  if (loading) return <div style={{ padding: "20px 28px", color: "var(--color-text-muted)", fontSize: 13 }}>Loading…</div>;
+
+  const inputStyle = {
+    padding: "7px 10px",
+    borderRadius: 6,
+    border: "1px solid var(--color-border)",
+    background: "var(--color-surface-2)",
+    color: "var(--color-text-primary)",
+    fontSize: 13,
+    fontFamily: "inherit",
+    outline: "none",
+    width: "100%",
+  };
+
+  return (
+    <div style={{ padding: "20px 28px", display: "flex", flexDirection: "column", gap: 16, height: "100%", overflowY: "auto" }}>
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <input
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Search properties…"
+          style={{ ...inputStyle, flex: 1 }}
+        />
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 16px", border: "none", borderRadius: 7, background: saved ? "#22c55e" : "var(--color-orange-primary)", color: "#fff", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit", flexShrink: 0, transition: "background 0.2s" }}
+        >
+          <Save size={14} />
+          {saved ? "Saved!" : saving ? "Saving…" : "Save Changes"}
+        </button>
+      </div>
+      {error && <p style={{ fontSize: 12, color: "#ef4444", margin: 0 }}>{error}</p>}
+
+      {props.length === 0 ? (
+        <p style={{ color: "var(--color-text-muted)", fontSize: 13 }}>No server.properties found — start the server once to generate it.</p>
+      ) : (
+        <>
+          {/* Known properties */}
+          {knownProps.length > 0 && (
+            <div>
+              <div style={{ fontSize: 11, fontWeight: 700, color: "var(--color-text-muted)", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 8 }}>Common Settings</div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                {knownProps.map(p => {
+                  const meta = KNOWN[p.key];
+                  return (
+                    <div key={p.key} style={{ display: "grid", gridTemplateColumns: "220px 1fr", alignItems: "center", gap: 12, padding: "8px 12px", borderRadius: 7, background: "var(--color-surface-1)", border: "1px solid var(--color-border)" }}>
+                      <div>
+                        <div style={{ fontSize: 13, fontWeight: 500 }}>{meta.label}</div>
+                        {meta.description && <div style={{ fontSize: 11, color: "var(--color-text-muted)" }}>{meta.description}</div>}
+                      </div>
+                      {meta.type === "boolean" ? (
+                        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                          <button
+                            onClick={() => setValue(p.key, p.value === "true" ? "false" : "true")}
+                            style={{
+                              width: 40, height: 22, borderRadius: 11, border: "none", cursor: "pointer",
+                              background: p.value === "true" ? "var(--color-orange-primary)" : "var(--color-surface-3)",
+                              position: "relative", transition: "background 0.15s",
+                            }}
+                          >
+                            <div style={{
+                              width: 16, height: 16, borderRadius: "50%", background: "#fff",
+                              position: "absolute", top: 3,
+                              left: p.value === "true" ? 21 : 3,
+                              transition: "left 0.15s",
+                            }} />
+                          </button>
+                          <span style={{ fontSize: 12, color: "var(--color-text-muted)" }}>{p.value === "true" ? "Enabled" : "Disabled"}</span>
+                        </div>
+                      ) : (
+                        <input
+                          value={p.value}
+                          onChange={e => setValue(p.key, e.target.value)}
+                          type={meta.type === "number" ? "number" : "text"}
+                          style={inputStyle}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Other properties */}
+          {otherProps.length > 0 && (
+            <div>
+              <div style={{ fontSize: 11, fontWeight: 700, color: "var(--color-text-muted)", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 8 }}>Advanced Settings</div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                {otherProps.map(p => (
+                  <div key={p.key} style={{ display: "grid", gridTemplateColumns: "220px 1fr", alignItems: "center", gap: 12, padding: "8px 12px", borderRadius: 7, background: "var(--color-surface-1)", border: "1px solid var(--color-border)" }}>
+                    <div style={{ fontSize: 12, fontFamily: "monospace", color: "var(--color-text-secondary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{p.key}</div>
+                    <input
+                      value={p.value}
+                      onChange={e => setValue(p.key, e.target.value)}
+                      style={inputStyle}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ServerSettingsEditor.tsx
+++ b/src/components/ServerSettingsEditor.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { Save } from "lucide-react";
+import type { ServerInfo, UpdateServerRequest } from "../types";
+import { updateServer } from "../lib/tauri";
+
+const RAM_OPTIONS = [512, 1024, 2048, 4096, 8192];
+
+export default function ServerSettingsEditor({
+  server,
+  onSaved,
+}: {
+  server: ServerInfo;
+  onSaved: (updated: ServerInfo) => void;
+}) {
+  const [name, setName] = useState(server.name);
+  const [ram, setRam] = useState(server.max_ram_mb);
+  const [autoRestart, setAutoRestart] = useState(server.auto_restart);
+  const [jvmFlags, setJvmFlags] = useState(server.jvm_flags);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSave() {
+    if (!name.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const req: UpdateServerRequest = { name: name.trim(), max_ram_mb: ram, auto_restart: autoRestart, jvm_flags: jvmFlags };
+      const updated = await updateServer(server.id, req);
+      onSaved({ ...server, ...updated });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (e) { setError(String(e)); }
+    finally { setSaving(false); }
+  }
+
+  const inputStyle = { padding: "8px 12px", borderRadius: 7, border: "1px solid var(--color-border)", background: "var(--color-surface-2)", color: "var(--color-text-primary)", fontSize: 13, fontFamily: "inherit", outline: "none", width: "100%" };
+
+  const row = (label: string, node: React.ReactNode, hint?: string) => (
+    <div style={{ display: "grid", gridTemplateColumns: "180px 1fr", alignItems: "center", gap: 12, padding: "10px 0", borderBottom: "1px solid var(--color-border)" }}>
+      <div>
+        <div style={{ fontSize: 13, fontWeight: 500 }}>{label}</div>
+        {hint && <div style={{ fontSize: 11, color: "var(--color-text-muted)" }}>{hint}</div>}
+      </div>
+      {node}
+    </div>
+  );
+
+  return (
+    <div style={{ padding: "20px 28px", display: "flex", flexDirection: "column", gap: 4 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+        <div style={{ fontWeight: 600, fontSize: 14 }}>Server Settings</div>
+        <button
+          onClick={handleSave}
+          disabled={saving || !name.trim()}
+          style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 16px", border: "none", borderRadius: 7, background: saved ? "#22c55e" : "var(--color-orange-primary)", color: "#fff", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit", transition: "background 0.2s", opacity: !name.trim() ? 0.5 : 1 }}
+        >
+          <Save size={14} />
+          {saved ? "Saved!" : saving ? "Saving…" : "Save Changes"}
+        </button>
+      </div>
+      {error && <p style={{ fontSize: 12, color: "#ef4444", margin: "0 0 10px" }}>{error}</p>}
+
+      {row("Display Name", <input value={name} onChange={e => setName(e.target.value)} style={inputStyle} />)}
+      {row("Max RAM",
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {RAM_OPTIONS.map(mb => (
+            <button
+              key={mb}
+              onClick={() => setRam(mb)}
+              style={{ padding: "6px 14px", border: `1px solid ${ram === mb ? "var(--color-orange-primary)" : "var(--color-border)"}`, borderRadius: 6, background: ram === mb ? "var(--color-orange-primary)" : "transparent", color: ram === mb ? "#fff" : "var(--color-text-secondary)", fontSize: 12, cursor: "pointer", fontFamily: "inherit", fontWeight: 500 }}
+            >
+              {mb >= 1024 ? `${mb / 1024}GB` : `${mb}MB`}
+            </button>
+          ))}
+        </div>
+      )}
+      {row("Auto-restart on crash",
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <button
+            onClick={() => setAutoRestart(v => !v)}
+            style={{ width: 40, height: 22, borderRadius: 11, border: "none", cursor: "pointer", background: autoRestart ? "var(--color-orange-primary)" : "var(--color-surface-3)", position: "relative", transition: "background 0.15s" }}
+          >
+            <div style={{ width: 16, height: 16, borderRadius: "50%", background: "#fff", position: "absolute", top: 3, left: autoRestart ? 21 : 3, transition: "left 0.15s" }} />
+          </button>
+          <span style={{ fontSize: 12, color: "var(--color-text-muted)" }}>{autoRestart ? "Enabled" : "Disabled"}</span>
+        </div>,
+        "Automatically restart if the server process crashes unexpectedly"
+      )}
+      {row("JVM Flags",
+        <input value={jvmFlags} onChange={e => setJvmFlags(e.target.value)} placeholder="-XX:+UseG1GC -XX:MaxGCPauseMillis=200" style={inputStyle} />,
+        "Extra JVM arguments added at startup (advanced)"
+      )}
+
+      {/* Read-only info */}
+      <div style={{ marginTop: 16, padding: "12px 0", borderTop: "1px solid var(--color-border)" }}>
+        <div style={{ fontSize: 11, fontWeight: 700, color: "var(--color-text-muted)", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 10 }}>Server Info</div>
+        {[
+          ["Server ID", server.id],
+          ["Type", server.server_type],
+          ["Version", server.minecraft_version],
+          ["Port", String(server.port)],
+          ["Created", new Date(server.created_at).toLocaleString()],
+        ].map(([k, v]) => (
+          <div key={k} style={{ display: "flex", gap: 12, padding: "5px 0", borderBottom: "1px solid var(--color-border)" }}>
+            <span style={{ width: 180, fontSize: 12, color: "var(--color-text-muted)", flexShrink: 0 }}>{k}</span>
+            <span style={{ fontSize: 12, fontFamily: "monospace", color: "var(--color-text-secondary)" }}>{v}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,14 +1,20 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
   AppSettings,
+  BackupInfo,
   CreateServerRequest,
   FileEntry,
   McVersion,
+  PlayerListEntry,
   PlayersResult,
+  PropertyEntry,
+  ResourceUsage,
+  ScheduledTask,
   ServerConfig,
   ServerInfo,
   ServerType,
   StatusEvent,
+  UpdateServerRequest,
 } from "../types";
 
 export const listServers = (): Promise<ServerInfo[]> =>
@@ -19,6 +25,9 @@ export const createServer = (req: CreateServerRequest): Promise<ServerConfig> =>
 
 export const deleteServer = (id: string): Promise<void> =>
   invoke("delete_server", { id });
+
+export const updateServer = (id: string, req: UpdateServerRequest): Promise<ServerConfig> =>
+  invoke("update_server", { id, req });
 
 export const startServer = (id: string): Promise<void> =>
   invoke("start_server", { id });
@@ -56,6 +65,9 @@ export const deleteServerFile = (id: string, path: string): Promise<void> =>
 export const openServerFile = (id: string, path: string | null): Promise<void> =>
   invoke("open_server_file", { id, path });
 
+export const uploadServerFile = (id: string, path: string, contentB64: string): Promise<void> =>
+  invoke("upload_server_file", { id, path, contentB64 });
+
 export const getSettings = (): Promise<AppSettings> =>
   invoke("get_settings");
 
@@ -67,3 +79,50 @@ export const getDataDir = (): Promise<string> =>
 
 export const openPath = (path: string): Promise<void> =>
   invoke("open_path", { path });
+
+// Resource monitor
+export const getServerResources = (id: string): Promise<ResourceUsage> =>
+  invoke("get_server_resources", { id });
+
+// Backups
+export const listBackups = (id: string): Promise<BackupInfo[]> =>
+  invoke("list_backups", { id });
+
+export const createBackup = (id: string, label?: string): Promise<BackupInfo> =>
+  invoke("create_backup", { id, label: label ?? null });
+
+export const deleteBackup = (id: string, name: string): Promise<void> =>
+  invoke("delete_backup", { id, name });
+
+export const restoreBackup = (id: string, name: string): Promise<void> =>
+  invoke("restore_backup", { id, name });
+
+// Server properties
+export const getServerProperties = (id: string): Promise<PropertyEntry[]> =>
+  invoke("get_server_properties", { id });
+
+export const saveServerProperties = (id: string, props: PropertyEntry[]): Promise<void> =>
+  invoke("save_server_properties", { id, props });
+
+// Player lists
+export const getPlayerList = (id: string, listType: string): Promise<PlayerListEntry[]> =>
+  invoke("get_player_list", { id, listType });
+
+export const addToPlayerList = (id: string, listType: string, username: string): Promise<void> =>
+  invoke("add_to_player_list", { id, listType, username });
+
+export const removeFromPlayerList = (id: string, listType: string, uuid: string): Promise<void> =>
+  invoke("remove_from_player_list", { id, listType, uuid });
+
+// Scheduled tasks
+export const getScheduledTasks = (id: string): Promise<ScheduledTask[]> =>
+  invoke("get_scheduled_tasks", { id });
+
+export const addScheduledTask = (id: string, task: Omit<ScheduledTask, "id" | "last_run">): Promise<ScheduledTask> =>
+  invoke("add_scheduled_task", { id, task: { ...task, id: "", last_run: null } });
+
+export const updateScheduledTask = (id: string, task: ScheduledTask): Promise<void> =>
+  invoke("update_scheduled_task", { id, task });
+
+export const removeScheduledTask = (id: string, taskId: string): Promise<void> =>
+  invoke("remove_scheduled_task", { id, taskId });

--- a/src/pages/ServerView.tsx
+++ b/src/pages/ServerView.tsx
@@ -2,28 +2,48 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { listen } from "@tauri-apps/api/event";
 import {
+  Archive,
   ArrowLeft,
+  Clock,
+  Cpu,
   FolderOpen,
   Play,
   RefreshCw,
+  Settings,
+  Sliders,
   Square,
   Terminal,
   Users,
 } from "lucide-react";
-import type { LogEvent, PlayerInfo, ServerInfo, StatusEvent } from "../types";
+import type { LogEvent, ResourceUsage, ServerInfo, StatusEvent } from "../types";
 import FileManager from "../components/FileManager";
 import ServerTypeIcon from "../components/ServerTypeIcon";
+import StatusBadge from "../components/StatusBadge";
+import BackupManager from "../components/BackupManager";
+import ServerPropertiesEditor from "../components/ServerPropertiesEditor";
+import PlayerListManager from "../components/PlayerListManager";
+import SchedulerManager from "../components/SchedulerManager";
+import ServerSettingsEditor from "../components/ServerSettingsEditor";
 import {
+  getServerResources,
   listServers,
-  queryPlayers,
   restartServer,
   sendCommand,
   startServer,
   stopServer,
 } from "../lib/tauri";
-import StatusBadge from "../components/StatusBadge";
 
-type Tab = "console" | "players" | "files";
+type Tab = "console" | "players" | "files" | "properties" | "backups" | "scheduler" | "config";
+
+const TABS: { id: Tab; label: string; icon: React.ReactNode }[] = [
+  { id: "console", label: "Console", icon: <Terminal size={14} /> },
+  { id: "players", label: "Players", icon: <Users size={14} /> },
+  { id: "files", label: "Files", icon: <FolderOpen size={14} /> },
+  { id: "properties", label: "Properties", icon: <Sliders size={14} /> },
+  { id: "backups", label: "Backups", icon: <Archive size={14} /> },
+  { id: "scheduler", label: "Scheduler", icon: <Clock size={14} /> },
+  { id: "config", label: "Settings", icon: <Settings size={14} /> },
+];
 
 const LOG_COLORS: Record<string, string> = {
   ERROR: "#ef4444",
@@ -39,8 +59,7 @@ export default function ServerView() {
   const [tab, setTab] = useState<Tab>("console");
   const [logs, setLogs] = useState<LogEvent[]>([]);
   const [command, setCommand] = useState("");
-  const [players, setPlayers] = useState<PlayerInfo[]>([]);
-  const [loadingPlayers, setLoadingPlayers] = useState(false);
+  const [resources, setResources] = useState<ResourceUsage | null>(null);
   const logEndRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
 
@@ -51,9 +70,7 @@ export default function ServerView() {
     setServer(found);
   }
 
-  useEffect(() => {
-    refresh();
-  }, [id]);
+  useEffect(() => { refresh(); }, [id]);
 
   useEffect(() => {
     if (!id) return;
@@ -64,14 +81,7 @@ export default function ServerView() {
     const unlistenStatus = listen<StatusEvent>("server-status", (e) => {
       if (e.payload.server_id !== id) return;
       setServer((prev) =>
-        prev
-          ? {
-              ...prev,
-              status: e.payload.status,
-              players_online: e.payload.players_online,
-              players_max: e.payload.players_max,
-            }
-          : prev
+        prev ? { ...prev, status: e.payload.status, players_online: e.payload.players_online, players_max: e.payload.players_max } : prev
       );
     });
     return () => {
@@ -81,30 +91,21 @@ export default function ServerView() {
   }, [id]);
 
   useEffect(() => {
-    if (autoScroll) {
-      logEndRef.current?.scrollIntoView({ behavior: "smooth" });
-    }
+    if (autoScroll) logEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [logs, autoScroll]);
 
-  async function fetchPlayers() {
-    if (!id) return;
-    setLoadingPlayers(true);
-    try {
-      const result = await queryPlayers(id);
-      setPlayers(result.sample);
-    } catch {
-      setPlayers([]);
-    } finally {
-      setLoadingPlayers(false);
-    }
-  }
-
+  // Poll resource usage while running
   useEffect(() => {
-    if (tab !== "players") return;
-    fetchPlayers();
-    const interval = setInterval(fetchPlayers, 10000);
+    if (!id || !server) return;
+    if (server.status !== "running") { setResources(null); return; }
+    const poll = async () => {
+      try { setResources(await getServerResources(id)); } catch {}
+    };
+    poll();
+    const interval = setInterval(poll, 5000);
     return () => clearInterval(interval);
-  }, [tab, id]);
+  }, [id, server?.status]);
+
 
   async function handleToggle() {
     if (!id || !server) return;
@@ -130,11 +131,7 @@ export default function ServerView() {
   }
 
   if (!server) {
-    return (
-      <div style={{ padding: 28 }}>
-        <p style={{ color: "var(--color-text-muted)" }}>Loading…</p>
-      </div>
-    );
+    return <div style={{ padding: 28 }}><p style={{ color: "var(--color-text-muted)" }}>Loading…</p></div>;
   }
 
   const isRunning = server.status === "running" || server.status === "starting";
@@ -142,50 +139,34 @@ export default function ServerView() {
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
       {/* Top bar */}
-      <div
-        style={{
-          padding: "16px 28px",
-          borderBottom: "1px solid var(--color-border)",
-          display: "flex",
-          alignItems: "center",
-          gap: 14,
-          flexShrink: 0,
-        }}
-      >
-        <button
-          onClick={() => navigate("/")}
-          style={{
-            background: "transparent",
-            border: "none",
-            cursor: "pointer",
-            color: "var(--color-text-muted)",
-            display: "flex",
-            padding: 4,
-            borderRadius: 6,
-          }}
-        >
+      <div style={{ padding: "14px 28px", borderBottom: "1px solid var(--color-border)", display: "flex", alignItems: "center", gap: 14, flexShrink: 0 }}>
+        <button onClick={() => navigate("/")} style={{ background: "transparent", border: "none", cursor: "pointer", color: "var(--color-text-muted)", display: "flex", padding: 4, borderRadius: 6 }}>
           <ArrowLeft size={18} />
         </button>
 
-        <div
-          style={{
-            width: 36,
-            height: 36,
-            borderRadius: 8,
-            backgroundColor: "var(--color-surface-2)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            fontSize: 20,
-          }}
-        >
+        <div style={{ width: 36, height: 36, borderRadius: 8, backgroundColor: "var(--color-surface-2)", display: "flex", alignItems: "center", justifyContent: "center" }}>
           <ServerTypeIcon type={server.server_type} size={28} />
         </div>
 
         <div style={{ flex: 1 }}>
           <div style={{ fontWeight: 700, fontSize: 16 }}>{server.name}</div>
-          <div style={{ fontSize: 12, color: "var(--color-text-muted)", textTransform: "capitalize" }}>
-            {server.server_type} {server.minecraft_version} · :{server.port}
+          <div style={{ fontSize: 12, color: "var(--color-text-muted)", textTransform: "capitalize", display: "flex", alignItems: "center", gap: 8 }}>
+            <span>{server.server_type} {server.minecraft_version} · :{server.port}</span>
+            {resources && (
+              <>
+                <span style={{ color: "var(--color-border)" }}>·</span>
+                <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                  <Cpu size={10} />
+                  {resources.cpu_percent.toFixed(1)}% CPU
+                </span>
+                <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                  {resources.ram_mb} MB RAM
+                </span>
+              </>
+            )}
+            {server.auto_restart && (
+              <span style={{ padding: "1px 6px", borderRadius: 99, fontSize: 10, background: "rgba(249,115,22,0.15)", color: "var(--color-orange-primary)", fontWeight: 600 }}>AUTO-RESTART</span>
+            )}
           </div>
         </div>
 
@@ -195,100 +176,31 @@ export default function ServerView() {
           <button
             onClick={handleToggle}
             disabled={server.status === "starting" || server.status === "stopping"}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 6,
-              padding: "8px 16px",
-              border: "none",
-              borderRadius: 8,
-              background: isRunning ? "var(--color-surface-3)" : "var(--color-orange-primary)",
-              color: isRunning ? "var(--color-text-secondary)" : "#fff",
-              fontSize: 13,
-              fontWeight: 600,
-              cursor: "pointer",
-              fontFamily: "inherit",
-              opacity: server.status === "starting" || server.status === "stopping" ? 0.5 : 1,
-            }}
+            style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 16px", border: "none", borderRadius: 8, background: isRunning ? "var(--color-surface-3)" : "var(--color-orange-primary)", color: isRunning ? "var(--color-text-secondary)" : "#fff", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit", opacity: server.status === "starting" || server.status === "stopping" ? 0.5 : 1 }}
           >
             {isRunning ? <Square size={13} /> : <Play size={13} />}
             {isRunning ? "Stop" : "Start"}
           </button>
-
           {isRunning && (
-            <button
-              onClick={handleRestart}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 6,
-                padding: "8px 14px",
-                border: "1px solid var(--color-border)",
-                borderRadius: 8,
-                background: "transparent",
-                color: "var(--color-text-secondary)",
-                fontSize: 13,
-                fontWeight: 500,
-                cursor: "pointer",
-                fontFamily: "inherit",
-              }}
-            >
-              <RefreshCw size={13} />
-              Restart
+            <button onClick={handleRestart} style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 14px", border: "1px solid var(--color-border)", borderRadius: 8, background: "transparent", color: "var(--color-text-secondary)", fontSize: 13, fontWeight: 500, cursor: "pointer", fontFamily: "inherit" }}>
+              <RefreshCw size={13} /> Restart
             </button>
           )}
         </div>
       </div>
 
       {/* Tabs */}
-      <div
-        style={{
-          display: "flex",
-          gap: 2,
-          padding: "0 28px",
-          borderBottom: "1px solid var(--color-border)",
-          flexShrink: 0,
-        }}
-      >
-        {(["console", "players", "files"] as Tab[]).map((t) => (
+      <div style={{ display: "flex", gap: 0, padding: "0 28px", borderBottom: "1px solid var(--color-border)", flexShrink: 0, overflowX: "auto" }}>
+        {TABS.map(({ id: tid, label, icon }) => (
           <button
-            key={t}
-            onClick={() => setTab(t)}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 7,
-              padding: "12px 16px",
-              border: "none",
-              borderBottom: tab === t ? "2px solid var(--color-orange-primary)" : "2px solid transparent",
-              background: "transparent",
-              color: tab === t ? "var(--color-orange-primary)" : "var(--color-text-muted)",
-              fontSize: 13,
-              fontWeight: 600,
-              cursor: "pointer",
-              fontFamily: "inherit",
-              textTransform: "capitalize",
-              marginBottom: -1,
-            }}
+            key={tid}
+            onClick={() => setTab(tid)}
+            style={{ display: "flex", alignItems: "center", gap: 7, padding: "12px 14px", border: "none", borderBottom: tab === tid ? "2px solid var(--color-orange-primary)" : "2px solid transparent", background: "transparent", color: tab === tid ? "var(--color-orange-primary)" : "var(--color-text-muted)", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit", whiteSpace: "nowrap", marginBottom: -1 }}
           >
-            {t === "console" ? (
-              <Terminal size={14} />
-            ) : t === "players" ? (
-              <Users size={14} />
-            ) : (
-              <FolderOpen size={14} />
-            )}
-            {t}
-            {t === "players" && (
-              <span
-                style={{
-                  padding: "1px 6px",
-                  borderRadius: 99,
-                  fontSize: 11,
-                  backgroundColor: "var(--color-surface-3)",
-                  color: "var(--color-text-muted)",
-                }}
-              >
+            {icon}
+            {label}
+            {tid === "players" && (
+              <span style={{ padding: "1px 6px", borderRadius: 99, fontSize: 11, backgroundColor: "var(--color-surface-3)", color: "var(--color-text-muted)" }}>
                 {server.players_online}
               </span>
             )}
@@ -300,26 +212,34 @@ export default function ServerView() {
       <div style={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column" }}>
         {tab === "files" ? (
           <FileManager serverId={id!} />
-        ) : tab === "console" ? (
+        ) : tab === "properties" ? (
+          <div style={{ flex: 1, overflowY: "auto" }}>
+            <ServerPropertiesEditor serverId={id!} />
+          </div>
+        ) : tab === "backups" ? (
+          <div style={{ flex: 1, overflowY: "auto" }}>
+            <BackupManager serverId={id!} />
+          </div>
+        ) : tab === "scheduler" ? (
+          <div style={{ flex: 1, overflowY: "auto" }}>
+            <SchedulerManager serverId={id!} />
+          </div>
+        ) : tab === "config" ? (
+          <div style={{ flex: 1, overflowY: "auto" }}>
+            <ServerSettingsEditor server={server} onSaved={(updated) => setServer(updated)} />
+          </div>
+        ) : tab === "players" ? (
+          <PlayerListManager serverId={id!} />
+        ) : (
+          /* Console */
           <>
-            {/* Log area */}
             <div
               onScroll={(e) => {
                 const el = e.currentTarget;
                 const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
                 setAutoScroll(atBottom);
               }}
-              style={{
-                flex: 1,
-                overflowY: "auto",
-                padding: "16px 28px",
-                fontFamily: '"JetBrains Mono", "Fira Code", "Consolas", monospace',
-                fontSize: 12,
-                lineHeight: 1.7,
-                display: "flex",
-                flexDirection: "column",
-                gap: 1,
-              }}
+              style={{ flex: 1, overflowY: "auto", padding: "16px 28px", fontFamily: '"JetBrains Mono", "Fira Code", "Consolas", monospace', fontSize: 12, lineHeight: 1.7, display: "flex", flexDirection: "column", gap: 1 }}
             >
               {logs.length === 0 ? (
                 <span style={{ color: "var(--color-text-muted)" }}>
@@ -327,156 +247,31 @@ export default function ServerView() {
                 </span>
               ) : (
                 logs.map((log, i) => (
-                  <div
-                    key={i}
-                    style={{ color: LOG_COLORS[log.level] ?? "var(--color-text-secondary)" }}
-                  >
+                  <div key={i} style={{ color: LOG_COLORS[log.level] ?? "var(--color-text-secondary)" }}>
                     {log.line}
                   </div>
                 ))
               )}
               <div ref={logEndRef} />
             </div>
-
-            {/* Command input */}
-            <form
-              onSubmit={handleSendCommand}
-              style={{
-                display: "flex",
-                gap: 8,
-                padding: "12px 28px",
-                borderTop: "1px solid var(--color-border)",
-                flexShrink: 0,
-              }}
-            >
-              <span
-                style={{
-                  padding: "10px 0",
-                  color: "var(--color-orange-primary)",
-                  fontFamily: "monospace",
-                  fontSize: 14,
-                  userSelect: "none",
-                }}
-              >
-                /
-              </span>
+            <form onSubmit={handleSendCommand} style={{ display: "flex", gap: 8, padding: "12px 28px", borderTop: "1px solid var(--color-border)", flexShrink: 0 }}>
+              <span style={{ padding: "10px 0", color: "var(--color-orange-primary)", fontFamily: "monospace", fontSize: 14, userSelect: "none" }}>/</span>
               <input
                 value={command}
                 onChange={(e) => setCommand(e.target.value)}
                 disabled={!isRunning}
                 placeholder={isRunning ? "Enter command…" : "Server is not running"}
-                style={{
-                  flex: 1,
-                  padding: "9px 12px",
-                  border: "1px solid var(--color-border)",
-                  borderRadius: 8,
-                  background: "var(--color-surface-2)",
-                  color: "var(--color-text-primary)",
-                  fontSize: 13,
-                  fontFamily: "monospace",
-                  outline: "none",
-                  opacity: isRunning ? 1 : 0.5,
-                }}
+                style={{ flex: 1, padding: "9px 12px", border: "1px solid var(--color-border)", borderRadius: 8, background: "var(--color-surface-2)", color: "var(--color-text-primary)", fontSize: 13, fontFamily: "monospace", outline: "none", opacity: isRunning ? 1 : 0.5 }}
               />
               <button
                 type="submit"
                 disabled={!isRunning || !command.trim()}
-                style={{
-                  padding: "9px 16px",
-                  border: "none",
-                  borderRadius: 8,
-                  background: "var(--color-orange-primary)",
-                  color: "#fff",
-                  fontSize: 13,
-                  fontWeight: 600,
-                  cursor: "pointer",
-                  fontFamily: "inherit",
-                  opacity: !isRunning || !command.trim() ? 0.4 : 1,
-                }}
+                style={{ padding: "9px 16px", border: "none", borderRadius: 8, background: "var(--color-orange-primary)", color: "#fff", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit", opacity: !isRunning || !command.trim() ? 0.4 : 1 }}
               >
                 Send
               </button>
             </form>
           </>
-        ) : (
-          <div style={{ flex: 1, overflowY: "auto", padding: "20px 28px" }}>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                marginBottom: 16,
-              }}
-            >
-              <span style={{ fontSize: 13, color: "var(--color-text-muted)" }}>
-                {server.players_online} / {server.players_max} players online
-              </span>
-              <button
-                onClick={fetchPlayers}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 6,
-                  padding: "7px 12px",
-                  border: "1px solid var(--color-border)",
-                  borderRadius: 7,
-                  background: "transparent",
-                  color: "var(--color-text-secondary)",
-                  fontSize: 12,
-                  fontWeight: 500,
-                  cursor: "pointer",
-                  fontFamily: "inherit",
-                }}
-              >
-                <RefreshCw size={12} />
-                Refresh
-              </button>
-            </div>
-
-            {loadingPlayers ? (
-              <p style={{ color: "var(--color-text-muted)", fontSize: 13 }}>Querying server…</p>
-            ) : players.length === 0 ? (
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  padding: "40px 0",
-                  gap: 10,
-                  color: "var(--color-text-muted)",
-                }}
-              >
-                <Users size={36} strokeWidth={1} />
-                <p style={{ margin: 0, fontSize: 14 }}>No players online</p>
-              </div>
-            ) : (
-              <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-                {players.map((p) => (
-                  <div
-                    key={p.id}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 12,
-                      padding: "10px 14px",
-                      borderRadius: 8,
-                      backgroundColor: "var(--color-surface-1)",
-                      border: "1px solid var(--color-border)",
-                    }}
-                  >
-                    <img
-                      src={`https://mc-heads.net/avatar/${p.name}/32`}
-                      alt={p.name}
-                      width={28}
-                      height={28}
-                      style={{ borderRadius: 4, imageRendering: "pixelated" }}
-                    />
-                    <span style={{ fontSize: 14, fontWeight: 500 }}>{p.name}</span>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
         )}
       </div>
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,11 @@
-export type ServerType = "vanilla" | "paper" | "fabric" | "forge" | "quilt" | "neoforge";
+export type ServerType =
+  | "vanilla"
+  | "paper"
+  | "fabric"
+  | "forge"
+  | "quilt"
+  | "neoforge";
+
 export type ServerStatus = "stopped" | "starting" | "running" | "stopping";
 
 export interface ServerConfig {
@@ -10,6 +17,8 @@ export interface ServerConfig {
   max_ram_mb: number;
   created_at: string;
   jar_name: string;
+  auto_restart: boolean;
+  jvm_flags: string;
 }
 
 export interface ServerInfo extends ServerConfig {
@@ -29,6 +38,15 @@ export interface CreateServerRequest {
   minecraft_version: string;
   port: number;
   max_ram_mb: number;
+  auto_restart: boolean;
+  jvm_flags: string;
+}
+
+export interface UpdateServerRequest {
+  name: string;
+  max_ram_mb: number;
+  auto_restart: boolean;
+  jvm_flags: string;
 }
 
 export interface LogEvent {
@@ -75,4 +93,42 @@ export interface AppSettings {
   default_ram_mb: number;
   default_port: number;
   show_snapshots: boolean;
+}
+
+export interface BackupInfo {
+  name: string;
+  size: number;
+  created_at: string;
+}
+
+export type ScheduledAction =
+  | { type: "command"; command: string }
+  | { type: "restart" };
+
+export interface ScheduledTask {
+  id: string;
+  label: string;
+  interval_minutes: number;
+  action: ScheduledAction;
+  enabled: boolean;
+  last_run: string | null;
+}
+
+export interface ResourceUsage {
+  cpu_percent: number;
+  ram_mb: number;
+}
+
+export interface PlayerListEntry {
+  uuid: string;
+  name: string;
+  level?: number;
+  reason?: string;
+  expires?: string;
+}
+
+export interface PropertyEntry {
+  key: string;
+  value: string;
+  comment?: string;
 }


### PR DESCRIPTION
## Summary

- **Resource monitor** — live CPU% and RAM usage in the server header, polled every 5s via `sysinfo`
- **Backups** — create labeled zip backups, list/restore/delete them from a dedicated tab
- **Server properties editor** — GUI form for `server.properties` with toggle switches for booleans, categorized into Common and Advanced
- **Player list management** — whitelist / ops / banlist CRUD with Mojang UUID lookup; sends runtime commands (`whitelist add`, `op`, `ban`, `pardon`) if the server is running
- **Scheduled tasks** — define interval-based tasks (run a command or restart) that execute in a background loop while the server is live
- **File upload** — Upload button in the file manager for dropping plugins, mods, configs, etc.
- **Auto-restart on crash** — detects unintentional process exit and restarts after 5s delay
- **JVM flags** — per-server extra startup args (e.g. `-XX:+UseG1GC`)
- **Server settings editor** — rename, change RAM, toggle auto-restart, edit JVM flags without recreating the server
- **New `ServerView` tabs** — Properties, Backups, Scheduler, Settings (alongside Console, Files)
- **Players tab** revamped to use `PlayerListManager` with whitelist/ops/banlist sub-navigation

## New backend commands (16)

`get_server_resources`, `list_backups`, `create_backup`, `delete_backup`, `restore_backup`, `get_server_properties`, `save_server_properties`, `get_player_list`, `add_to_player_list`, `remove_from_player_list`, `upload_server_file`, `get_scheduled_tasks`, `add_scheduled_task`, `update_scheduled_task`, `remove_scheduled_task`, `update_server`

## New frontend components (5)

`BackupManager`, `PlayerListManager`, `SchedulerManager`, `ServerPropertiesEditor`, `ServerSettingsEditor`

## Dependencies added

- `sysinfo = 0.33` — process CPU/RAM monitoring
- `zip = 2 (deflate only)` — pure-Rust zip for backup creation/restore
- `base64 = 0.22` — binary file upload encoding